### PR TITLE
Iptables Service

### DIFF
--- a/cmd/krood/main.go
+++ b/cmd/krood/main.go
@@ -22,6 +22,7 @@ import (
 	"github.com/kontainerooo/kontainer.ooo/pkg/abstraction"
 	"github.com/kontainerooo/kontainer.ooo/pkg/containerlifecycle"
 	"github.com/kontainerooo/kontainer.ooo/pkg/customercontainer"
+	"github.com/kontainerooo/kontainer.ooo/pkg/iptables"
 	"github.com/kontainerooo/kontainer.ooo/pkg/kmi"
 	kmiClient "github.com/kontainerooo/kontainer.ooo/pkg/kmi/client"
 	"github.com/kontainerooo/kontainer.ooo/pkg/pb"
@@ -110,10 +111,18 @@ func main() {
 
 	ccEndpoint := makeCustomerContainerServiceEndpoints(customercontainerService)
 
+	var iptablesService iptables.Service
+	iptablesService, err = iptables.NewService("iptables", dbWrapper)
+	if err != nil {
+		panic(err)
+	}
+
+	iptEndpoint := makeIPTServiceEndpoints(iptablesService)
+
 	errc := make(chan error)
 	ctx := context.Background()
 
-	go startGRPCTransport(ctx, errc, logger, grpcAddr, userEndpoints, kmiEndpoints, clsEndpoints, ccEndpoint)
+	go startGRPCTransport(ctx, errc, logger, grpcAddr, userEndpoints, kmiEndpoints, clsEndpoints, ccEndpoint, iptEndpoint)
 
 	go startWebsocketTransport(errc, logger, wsAddr, userEndpoints, kmiEndpoints, clsEndpoints, ccEndpoint)
 
@@ -138,7 +147,7 @@ func main() {
 	logger.Log("exit", <-errc)
 }
 
-func startGRPCTransport(ctx context.Context, errc chan error, logger log.Logger, grpcAddr string, ue user.Endpoints, ke kmi.Endpoints, cle containerlifecycle.Endpoints, cce customercontainer.Endpoints) {
+func startGRPCTransport(ctx context.Context, errc chan error, logger log.Logger, grpcAddr string, ue user.Endpoints, ke kmi.Endpoints, cle containerlifecycle.Endpoints, cce customercontainer.Endpoints, ipt iptables.Endpoints) {
 	logger = log.With(logger, "transport", "gRPC")
 
 	ln, err := net.Listen("tcp", grpcAddr)
@@ -159,6 +168,9 @@ func startGRPCTransport(ctx context.Context, errc chan error, logger log.Logger,
 
 	ccsServer := customercontainer.MakeGRPCServer(ctx, cce, logger)
 	pb.RegisterCustomerContainerServiceServer(s, ccsServer)
+
+	iptServer := iptables.MakeGRPCServer(ctx, ipt, logger)
+	pb.RegisterIPTablesServiceServer(s, iptServer)
 
 	logger.Log("addr", grpcAddr)
 	errc <- s.Serve(ln)
@@ -274,6 +286,29 @@ func makeCLServiceEndpoints(s containerlifecycle.Service) containerlifecycle.End
 		StartContainerEndpoint: StartContainerEndpoint,
 		StartCommandEndpoint:   StartCommandEndpoint,
 		StopContainerEndpoint:  StopContainerEndpoint,
+	}
+}
+
+func makeIPTServiceEndpoints(s iptables.Service) iptables.Endpoints {
+	var AddRuleEndpoint endpoint.Endpoint
+	{
+		AddRuleEndpoint = iptables.MakeAddRuleEndpoint(s)
+	}
+
+	var RemoveRuleEndpoint endpoint.Endpoint
+	{
+		RemoveRuleEndpoint = iptables.MakeRemoveRuleEndpoint(s)
+	}
+
+	var GetRulesForUserEndpoint endpoint.Endpoint
+	{
+		GetRulesForUserEndpoint = iptables.MakeGetRulesForUserEndpoint(s)
+	}
+
+	return iptables.Endpoints{
+		AddRuleEndpoint:         AddRuleEndpoint,
+		RemoveRuleEndpoint:      RemoveRuleEndpoint,
+		GetRulesForUserEndpoint: GetRulesForUserEndpoint,
 	}
 }
 

--- a/messages/iptables.proto
+++ b/messages/iptables.proto
@@ -1,0 +1,48 @@
+syntax = "proto3";
+package pb;
+
+service IPTablesService {
+    rpc AddRule (AddRuleRequest) returns (AddRuleResponse);
+    rpc RemoveRule (RemoveRuleRequest) returns (RemoveRuleResponse);
+    rpc GetRulesForUser (GetRulesForUserRequest) returns (GetRulesForUserResponse);
+}
+
+message IPTRule {
+    string Operation = 1;
+    string Target = 2;
+    string Chain = 3;
+    string Protocol = 4;
+    string In = 5;
+    string Out = 6;
+    string Source = 7;
+    string Destination = 8;
+    uint32 SourcePort = 9;
+    uint32 DestinationPort = 10;
+    string state = 11;
+}
+
+message AddRuleRequest {
+    uint32 Refid = 1;
+    IPTRule Rule = 2;
+}
+
+message AddRuleResponse {
+    string Error = 1;
+}
+
+message RemoveRuleRequest {
+    string ID = 1;
+}
+
+message RemoveRuleResponse {
+    string Error = 1;
+}
+
+message GetRulesForUserRequest {
+    uint32 Refid = 1;
+}
+
+message GetRulesForUserResponse {
+    repeated IPTRule Rules = 1;
+    string error = 2;
+}

--- a/pkg/firewall/datatypes.go
+++ b/pkg/firewall/datatypes.go
@@ -1,2 +1,8 @@
 // Package firewall handles the firewall and forwarding configuration
 package firewall
+
+type networkInterface struct {
+	ID    uint
+	refid uint
+	name  string
+}

--- a/pkg/firewall/service.go
+++ b/pkg/firewall/service.go
@@ -1,64 +1,66 @@
 // Package firewall handles the firewall and forwarding configuration
 package firewall
 
-// Service IPTablesService
+import "github.com/kontainerooo/kontainer.ooo/pkg/abstraction"
+
+// Service firewall
 type Service interface {
 
 	// InitBridge initializes a bridge network
-	InitBridge(ip string) error
+	InitBridge(ip abstraction.Inet, netIf string) error
 
 	// AllowConnection sets up a rule to let src talk to dst
-	AllowConnection(src string, dst string) error
+	AllowConnection(src abstraction.Inet, dst abstraction.Inet) error
 
 	// AllowConnection sets up a rule to block src from talking to dst
-	BlockConnection(src string, dst string) error
+	BlockConnection(src abstraction.Inet, dst abstraction.Inet) error
 
 	// AllowPort sets up a rule to let src talk to dst on port port
-	AllowPort(src string, dst string, port uint32) error
+	AllowPort(src abstraction.Inet, dst abstraction.Inet, port uint32) error
 
 	// AllowPort sets up a rule to block src from talking to dst on port port
-	BlockPort(src string, dst string, port uint32) error
+	BlockPort(src abstraction.Inet, dst abstraction.Inet, port uint32) error
 
 	// RedirectPort redirects the src port to the dst port on ip
-	RedirectPort(ip string, src uint32, dst uint32) error
+	RedirectPort(ip abstraction.Inet, src uint32, dst uint32) error
 
 	// RemoveRedirectPort removes a port redirection
-	RemoveRedirectPort(ip string, src uint32, dst uint32) error
+	RemoveRedirectPort(ip abstraction.Inet, src uint32, dst uint32) error
 }
 
 type service struct{}
 
-func (s *service) InitBridge(ip string) error {
+func (s *service) InitBridge(ip abstraction.Inet, netIf string) error {
 	// TODO: implement
 	return nil
 }
 
-func (s *service) AllowConnection(src string, dst string) error {
+func (s *service) AllowConnection(src abstraction.Inet, dst abstraction.Inet) error {
 	// TODO: implement
 	return nil
 }
 
-func (s *service) BlockConnection(src string, dst string) error {
+func (s *service) BlockConnection(src abstraction.Inet, dst abstraction.Inet) error {
 	// TODO: implement
 	return nil
 }
 
-func (s *service) AllowPort(src string, dst string, port uint32) error {
+func (s *service) AllowPort(src abstraction.Inet, dst abstraction.Inet, port uint32) error {
 	// TODO: implement
 	return nil
 }
 
-func (s *service) BlockPort(src string, dst string, port uint32) error {
+func (s *service) BlockPort(src abstraction.Inet, dst abstraction.Inet, port uint32) error {
 	// TODO: implement
 	return nil
 }
 
-func (s *service) RedirectPort(ip string, src uint32, dst uint32) error {
+func (s *service) RedirectPort(ip abstraction.Inet, src uint32, dst uint32) error {
 	// TODO: implement
 	return nil
 }
 
-func (s *service) RemoveRedirectPort(ip string, src uint32, dst uint32) error {
+func (s *service) RemoveRedirectPort(ip abstraction.Inet, src uint32, dst uint32) error {
 	// TODO: implement
 	return nil
 }

--- a/pkg/iptables/client/client.go
+++ b/pkg/iptables/client/client.go
@@ -1,0 +1,178 @@
+package client
+
+import (
+	"context"
+	"errors"
+
+	"github.com/go-kit/kit/endpoint"
+	"github.com/go-kit/kit/log"
+	grpctransport "github.com/go-kit/kit/transport/grpc"
+	"google.golang.org/grpc"
+
+	"github.com/kontainerooo/kontainer.ooo/pkg/abstraction"
+	"github.com/kontainerooo/kontainer.ooo/pkg/iptables"
+	"github.com/kontainerooo/kontainer.ooo/pkg/pb"
+)
+
+// New creates a set of endpoints based on a gRPC connection
+func New(conn *grpc.ClientConn, logger log.Logger) *iptables.Endpoints {
+
+	var AddRuleEndpoint endpoint.Endpoint
+	{
+		AddRuleEndpoint = grpctransport.NewClient(
+			conn,
+			"iptablesService",
+			"AddRule",
+			EncodeGRPCAddRuleRequest,
+			DecodeGRPCAddRuleResponse,
+			pb.AddRuleResponse{},
+		).Endpoint()
+	}
+
+	var RemoveRuleEndpoint endpoint.Endpoint
+	{
+		RemoveRuleEndpoint = grpctransport.NewClient(
+			conn,
+			"iptablesService",
+			"RemoveRule",
+			EncodeGRPCRemoveRuleRequest,
+			DecodeGRPCRemoveRuleResponse,
+			pb.RemoveRuleResponse{},
+		).Endpoint()
+	}
+
+	var GetRulesForUserEndpoint endpoint.Endpoint
+	{
+		GetRulesForUserEndpoint = grpctransport.NewClient(
+			conn,
+			"iptablesService",
+			"GetRulesForUser",
+			EncodeGRPCGetRulesForUserRequest,
+			DecodeGRPCGetRulesForUserResponse,
+			pb.GetRulesForUserResponse{},
+		).Endpoint()
+	}
+
+	return &iptables.Endpoints{
+		AddRuleEndpoint:         AddRuleEndpoint,
+		RemoveRuleEndpoint:      RemoveRuleEndpoint,
+		GetRulesForUserEndpoint: GetRulesForUserEndpoint,
+	}
+}
+
+func getError(e string) error {
+	if e != "" {
+		return errors.New(e)
+	}
+	return nil
+}
+
+func convertToIPTRule(r iptables.Rule) *pb.IPTRule {
+	return &pb.IPTRule{
+		Operation:       r.Operation,
+		Target:          r.Target,
+		Chain:           r.Chain,
+		Protocol:        r.Protocol,
+		In:              r.In,
+		Out:             r.Out,
+		Source:          string(r.Source),
+		Destination:     string(r.Destination),
+		SourcePort:      uint32(r.SourcePort),
+		DestinationPort: uint32(r.DestinationPort),
+		State:           r.State,
+	}
+}
+
+func convertToNativeRule(r *pb.IPTRule) (iptables.Rule, error) {
+	sourceIP, err := abstraction.NewInet(r.Source)
+	if err != nil {
+		return iptables.Rule{}, err
+	}
+
+	destIP, err := abstraction.NewInet(r.Destination)
+	if err != nil {
+		return iptables.Rule{}, err
+	}
+
+	return iptables.Rule{
+		Operation:       r.Operation,
+		Target:          r.Target,
+		Chain:           r.Chain,
+		Protocol:        r.Protocol,
+		In:              r.In,
+		Out:             r.Out,
+		Source:          sourceIP,
+		Destination:     destIP,
+		SourcePort:      uint16(r.SourcePort),
+		DestinationPort: uint16(r.DestinationPort),
+		State:           r.State,
+	}, nil
+}
+
+// EncodeGRPCAddRuleRequest is a transport/grpc.EncodeRequestFunc that converts a
+// messages/iptables.proto-domain addrule request to a gRPC AddRule request.
+func EncodeGRPCAddRuleRequest(_ context.Context, request interface{}) (interface{}, error) {
+	req := request.(*iptables.AddRuleRequest)
+	return &pb.AddRuleRequest{
+		Refid: uint32(req.Refid),
+		Rule:  convertToIPTRule(req.Rule),
+	}, nil
+}
+
+// DecodeGRPCAddRuleResponse is a transport/grpc.DecodeResponseFunc that converts a
+// gRPC AddRule response to a messages/iptables.proto-domain addrule response.
+func DecodeGRPCAddRuleResponse(_ context.Context, grpcResponse interface{}) (interface{}, error) {
+	response := grpcResponse.(*pb.AddRuleResponse)
+	return &iptables.AddRuleResponse{
+		Error: getError(response.Error),
+	}, nil
+}
+
+// EncodeGRPCRemoveRuleRequest is a transport/grpc.EncodeRequestFunc that converts a
+// messages/iptables.proto-domain removerule request to a gRPC RemoveRule request.
+func EncodeGRPCRemoveRuleRequest(_ context.Context, request interface{}) (interface{}, error) {
+	req := request.(*iptables.RemoveRuleRequest)
+	return &pb.RemoveRuleRequest{
+		ID: req.ID,
+	}, nil
+}
+
+// DecodeGRPCRemoveRuleResponse is a transport/grpc.DecodeResponseFunc that converts a
+// gRPC RemoveRule response to a messages/iptables.proto-domain removerule response.
+func DecodeGRPCRemoveRuleResponse(_ context.Context, grpcResponse interface{}) (interface{}, error) {
+	response := grpcResponse.(*pb.RemoveRuleResponse)
+	return &iptables.RemoveRuleResponse{
+		Error: getError(response.Error),
+	}, nil
+}
+
+// EncodeGRPCGetRulesForUserRequest is a transport/grpc.EncodeRequestFunc that converts a
+// messages/iptables.proto-domain getrulesforuser request to a gRPC GetRulesForUser request.
+func EncodeGRPCGetRulesForUserRequest(_ context.Context, request interface{}) (interface{}, error) {
+	req := request.(*iptables.GetRulesForUserRequest)
+	return &pb.GetRulesForUserRequest{
+		Refid: uint32(req.Refid),
+	}, nil
+}
+
+// DecodeGRPCGetRulesForUserResponse is a transport/grpc.DecodeResponseFunc that converts a
+// gRPC GetRulesForUser response to a messages/iptables.proto-domain getrulesforuser response.
+func DecodeGRPCGetRulesForUserResponse(_ context.Context, grpcResponse interface{}) (interface{}, error) {
+	response := grpcResponse.(*pb.GetRulesForUserResponse)
+
+	rules := []iptables.Rule{}
+	for _, v := range response.Rules {
+		rule, err := convertToNativeRule(v)
+		if err != nil {
+			return &iptables.GetRulesForUserResponse{
+				Error: getError(response.Error),
+			}, err
+		}
+		rules = append(rules, rule)
+	}
+
+	return &iptables.GetRulesForUserResponse{
+		Error: getError(response.Error),
+		Rules: rules,
+	}, nil
+}

--- a/pkg/iptables/client/client.go
+++ b/pkg/iptables/client/client.go
@@ -21,7 +21,7 @@ func New(conn *grpc.ClientConn, logger log.Logger) *iptables.Endpoints {
 	{
 		AddRuleEndpoint = grpctransport.NewClient(
 			conn,
-			"iptablesService",
+			"IPTablesService",
 			"AddRule",
 			EncodeGRPCAddRuleRequest,
 			DecodeGRPCAddRuleResponse,
@@ -33,7 +33,7 @@ func New(conn *grpc.ClientConn, logger log.Logger) *iptables.Endpoints {
 	{
 		RemoveRuleEndpoint = grpctransport.NewClient(
 			conn,
-			"iptablesService",
+			"IPTablesService",
 			"RemoveRule",
 			EncodeGRPCRemoveRuleRequest,
 			DecodeGRPCRemoveRuleResponse,
@@ -45,7 +45,7 @@ func New(conn *grpc.ClientConn, logger log.Logger) *iptables.Endpoints {
 	{
 		GetRulesForUserEndpoint = grpctransport.NewClient(
 			conn,
-			"iptablesService",
+			"IPTablesService",
 			"GetRulesForUser",
 			EncodeGRPCGetRulesForUserRequest,
 			DecodeGRPCGetRulesForUserResponse,

--- a/pkg/iptables/datatypes.go
+++ b/pkg/iptables/datatypes.go
@@ -5,6 +5,7 @@ import "github.com/kontainerooo/kontainer.ooo/pkg/abstraction"
 
 // Rule represents a rule entry in iptables
 type Rule struct {
+	Operation       string
 	Target          string
 	Chain           string
 	Protocol        string

--- a/pkg/iptables/endpoint.go
+++ b/pkg/iptables/endpoint.go
@@ -16,7 +16,7 @@ type Endpoints struct {
 // AddRuleRequest is the request struct for the AddRuleEndpoint
 type AddRuleRequest struct {
 	Refid uint
-	Rule  rule
+	Rule  Rule
 }
 
 // AddRuleResponse is the response struct for the AddRuleEndpoint

--- a/pkg/iptables/endpoint.go
+++ b/pkg/iptables/endpoint.go
@@ -1,0 +1,80 @@
+package iptables
+
+import (
+	"context"
+
+	"github.com/go-kit/kit/endpoint"
+)
+
+// Endpoints is a struct which collects all endpoints for the iptables service
+type Endpoints struct {
+	AddRuleEndpoint         endpoint.Endpoint
+	RemoveRuleEndpoint      endpoint.Endpoint
+	GetRulesForUserEndpoint endpoint.Endpoint
+}
+
+// AddRuleRequest is the request struct for the AddRuleEndpoint
+type AddRuleRequest struct {
+	Refid uint
+	Rule  rule
+}
+
+// AddRuleResponse is the response struct for the AddRuleEndpoint
+type AddRuleResponse struct {
+	Error error
+}
+
+// MakeAddRuleEndpoint creates a gokit endpoint which invokes AddRule
+func MakeAddRuleEndpoint(s Service) endpoint.Endpoint {
+	return func(ctx context.Context, request interface{}) (interface{}, error) {
+		req := request.(AddRuleRequest)
+		err := s.AddRule(req.Refid, req.Rule)
+		return AddRuleResponse{
+			Error: err,
+		}, nil
+	}
+}
+
+// RemoveRuleRequest is the request struct for the RemoveRuleEndpoint
+type RemoveRuleRequest struct {
+	ID string
+}
+
+// RemoveRuleResponse is the response struct for the RemoveRuleEndpoint
+type RemoveRuleResponse struct {
+	Error error
+}
+
+// MakeRemoveRuleEndpoint creates a gokit endpoint which invokes RemoveRule
+func MakeRemoveRuleEndpoint(s Service) endpoint.Endpoint {
+	return func(ctx context.Context, request interface{}) (interface{}, error) {
+		req := request.(RemoveRuleRequest)
+		err := s.RemoveRule(req.ID)
+		return RemoveRuleResponse{
+			Error: err,
+		}, nil
+	}
+}
+
+// GetRulesForUserRequest is the request struct for the GetRulesForUserEndpoint
+type GetRulesForUserRequest struct {
+	Refid uint
+}
+
+// GetRulesForUserResponse is the response struct for the GetRulesForUserEndpoint
+type GetRulesForUserResponse struct {
+	Rules []Rule
+	Error error
+}
+
+// MakeGetRulesForUserEndpoint creates a gokit endpoint which invokes GetRulesForUser
+func MakeGetRulesForUserEndpoint(s Service) endpoint.Endpoint {
+	return func(ctx context.Context, request interface{}) (interface{}, error) {
+		req := request.(GetRulesForUserRequest)
+		rules, err := s.GetRulesForUser(req.Refid)
+		return GetRulesForUserResponse{
+			Rules: rules,
+			Error: err,
+		}, nil
+	}
+}

--- a/pkg/iptables/iptables_test.go
+++ b/pkg/iptables/iptables_test.go
@@ -381,6 +381,37 @@ var _ = Describe("Iptables", func() {
 			})
 
 			Ω(err).Should(HaveOccurred())
+
+			iptablesIsPresent = 1
+		})
+	})
+
+	Describe("Delete Rules", func() {
+		hash := ""
+		It("Should delete a rule", func() {
+			ipts, _ := iptables.NewService("iptables", testutils.NewMockDB())
+			r := iptables.Rule{
+				Target:          "REDIRECT",
+				Chain:           "PREROUTING",
+				Protocol:        "tcp",
+				Destination:     simpleNewInet("127.0.0.2"),
+				SourcePort:      8080,
+				DestinationPort: 80,
+			}
+
+			ipts.AddRule(123, r)
+
+			hash = r.GetHash()
+			err := ipts.RemoveRule(hash)
+
+			Ω(err).ShouldNot(HaveOccurred())
+		})
+
+		It("Should error on non-existing rule", func() {
+			ipts, _ := iptables.NewService("iptables", testutils.NewMockDB())
+			err := ipts.RemoveRule(hash)
+
+			Ω(err).Should(HaveOccurred())
 		})
 	})
 })

--- a/pkg/iptables/iptables_test.go
+++ b/pkg/iptables/iptables_test.go
@@ -45,6 +45,7 @@ var _ = Describe("Iptables", func() {
 	Describe("Redirect rule string", func() {
 		It("Should create REDIRECT rule", func() {
 			r := iptables.Rule{
+				Operation:       "-A",
 				Target:          "REDIRECT",
 				Chain:           "PREROUTING",
 				Protocol:        "tcp",
@@ -138,6 +139,24 @@ var _ = Describe("Iptables", func() {
 
 			Ω(err).Should(HaveOccurred())
 			Ω(err).Should(Equal(iptables.ErrWrongProtocol))
+			Ω(str).Should(BeEmpty())
+		})
+
+		It("Should error on invalid operation", func() {
+			r := iptables.Rule{
+				Operation:       "-U",
+				Target:          "REDIRECT",
+				Chain:           "PREROUTING",
+				Protocol:        "tcp",
+				SourcePort:      8080,
+				Destination:     simpleNewInet("127.0.0.2"),
+				DestinationPort: 80,
+			}
+
+			str, err := r.ToString()
+
+			Ω(err).Should(HaveOccurred())
+			Ω(err).Should(Equal(iptables.ErrNotValidOperation))
 			Ω(str).Should(BeEmpty())
 		})
 	})

--- a/pkg/iptables/service.go
+++ b/pkg/iptables/service.go
@@ -15,7 +15,7 @@ type Service interface {
 	// RemoveRule removes a given iptables rule
 	RemoveRule(id string) error
 	// GetRulesForUser returns a list of all rules for a given user
-	GetRulesForUser(refid uint) []Rule
+	GetRulesForUser(refid uint) ([]Rule, error)
 	// CreateIPTablesBackup creates an iptables backup file
 	CreateIPTablesBackup() string
 	// LoadIPTablesBackup restores iptables from backup file
@@ -28,6 +28,7 @@ type dbAdapter interface {
 	Where(interface{}, ...interface{}) error
 	Create(interface{}) error
 	First(interface{}, ...interface{}) error
+	Find(interface{}, ...interface{}) error
 	Delete(interface{}, ...interface{}) error
 }
 
@@ -117,9 +118,18 @@ func (s *service) RemoveRule(id string) error {
 	return nil
 }
 
-func (s *service) GetRulesForUser(refid uint) []Rule {
-	// TODO: implement
-	return []Rule{}
+func (s *service) GetRulesForUser(refid uint) ([]Rule, error) {
+	rules := []Rule{}
+	ipt := []iptablesEntry{}
+	err := s.db.Find(&ipt)
+	if err != nil {
+		return []Rule{}, err
+	}
+
+	for _, entry := range ipt {
+		rules = append(rules, entry.Rule)
+	}
+	return rules, nil
 }
 
 func (s *service) CreateIPTablesBackup() string {

--- a/pkg/iptables/transport_grpc.go
+++ b/pkg/iptables/transport_grpc.go
@@ -1,0 +1,167 @@
+package iptables
+
+import (
+	"context"
+
+	"github.com/go-kit/kit/log"
+	grpctransport "github.com/go-kit/kit/transport/grpc"
+	"github.com/kontainerooo/kontainer.ooo/pkg/abstraction"
+	"github.com/kontainerooo/kontainer.ooo/pkg/pb"
+	oldcontext "golang.org/x/net/context"
+)
+
+// MakeGRPCServer makes a set of Endpoints available as a gRPC iptablesServer
+func MakeGRPCServer(ctx context.Context, endpoints Endpoints, logger log.Logger) pb.IPTABLESServiceServer {
+	options := []grpctransport.ServerOption{
+		grpctransport.ServerErrorLogger(logger),
+	}
+
+	return &grpcServer{
+		addrule: grpctransport.NewServer(
+			endpoints.AddRuleEndpoint,
+			DecodeGRPCAddRuleRequest,
+			EncodeGRPCAddRuleResponse,
+			options...,
+		),
+		removerule: grpctransport.NewServer(
+			endpoints.RemoveRuleEndpoint,
+			DecodeGRPCRemoveRuleRequest,
+			EncodeGRPCRemoveRuleResponse,
+			options...,
+		),
+		getrulesforuser: grpctransport.NewServer(
+			endpoints.GetRulesForUserEndpoint,
+			DecodeGRPCGetRulesForUserRequest,
+			EncodeGRPCGetRulesForUserResponse,
+			options...,
+		),
+	}
+}
+
+type grpcServer struct {
+	addrule         grpctransport.Handler
+	removerule      grpctransport.Handler
+	getrulesforuser grpctransport.Handler
+}
+
+func (s *grpcServer) AddRule(ctx oldcontext.Context, req *pb.AddRuleRequest) (*pb.AddRuleResponse, error) {
+	_, res, err := s.addrule.ServeGRPC(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	return res.(*pb.AddRuleResponse), nil
+}
+
+func (s *grpcServer) RemoveRule(ctx oldcontext.Context, req *pb.RemoveRuleRequest) (*pb.RemoveRuleResponse, error) {
+	_, res, err := s.removerule.ServeGRPC(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	return res.(*pb.RemoveRuleResponse), nil
+}
+
+func (s *grpcServer) GetRulesForUser(ctx oldcontext.Context, req *pb.GetRulesForUserRequest) (*pb.GetRulesForUserResponse, error) {
+	_, res, err := s.getrulesforuser.ServeGRPC(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	return res.(*pb.GetRulesForUserResponse), nil
+}
+
+func convertToNativeRule(r pb.IPTRule) Rule {
+	return Rule{
+		Operation:       r.Operation,
+		Target:          r.Target,
+		Chain:           r.Chain,
+		Protocol:        r.Protocol,
+		In:              r.In,
+		Out:             r.Out,
+		Source:          abstraction.NewInet(r.Source),
+		Destination:     abstraction.NewInet(Destination),
+		SourcePort:      uint16(r.SourcePort),
+		DestinationPort: uint16(r.DestinationPort),
+		State:           r.State,
+	}
+}
+
+// DecodeGRPCAddRuleRequest is a transport/grpc.DecodeRequestFunc that converts a
+// gRPC AddRule request to a messages/iptables.proto-domain addrule request.
+func DecodeGRPCAddRuleRequest(_ context.Context, grpcReq interface{}) (interface{}, error) {
+	req := grpcReq.(*pb.AddRuleRequest)
+	return AddRuleRequest{
+		Refid: uint(req.Refid),
+		Rule:  convertToNativeRule(req.Rule),
+	}, nil
+}
+
+// DecodeGRPCRemoveRuleRequest is a transport/grpc.DecodeRequestFunc that converts a
+// gRPC RemoveRule request to a messages/iptables.proto-domain removerule request.
+func DecodeGRPCRemoveRuleRequest(_ context.Context, grpcReq interface{}) (interface{}, error) {
+	req := grpcReq.(*pb.RemoveRuleRequest)
+	return RemoveRuleRequest{
+		ID: req.ID,
+	}, nil
+}
+
+// DecodeGRPCGetRulesForUserRequest is a transport/grpc.DecodeRequestFunc that converts a
+// gRPC GetRulesForUser request to a messages/iptables.proto-domain getrulesforuser request.
+func DecodeGRPCGetRulesForUserRequest(_ context.Context, grpcReq interface{}) (interface{}, error) {
+	req := grpcReq.(*pb.GetRulesForUserRequest)
+	return GetRulesForUserRequest{
+		Refid: req.Refid,
+	}, nil
+}
+
+// EncodeGRPCAddRuleResponse is a transport/grpc.EncodeRequestFunc that converts a
+// messages/iptables.proto-domain addrule response to a gRPC AddRule response.
+func EncodeGRPCAddRuleResponse(_ context.Context, response interface{}) (interface{}, error) {
+	res := response.(AddRuleResponse)
+	gRPCRes := &pb.AddRuleResponse{}
+	if res.Error != nil {
+		gRPCRes.Error = res.Error.Error()
+	}
+	return gRPCRes, nil
+}
+
+// EncodeGRPCRemoveRuleResponse is a transport/grpc.EncodeRequestFunc that converts a
+// messages/iptables.proto-domain removerule response to a gRPC RemoveRule response.
+func EncodeGRPCRemoveRuleResponse(_ context.Context, response interface{}) (interface{}, error) {
+	res := response.(RemoveRuleResponse)
+	gRPCRes := &pb.RemoveRuleResponse{}
+	if res.Error != nil {
+		gRPCRes.Error = res.Error.Error()
+	}
+	return gRPCRes, nil
+}
+
+// EncodeGRPCGetRulesForUserResponse is a transport/grpc.EncodeRequestFunc that converts a
+// messages/iptables.proto-domain getrulesforuser response to a gRPC GetRulesForUser response.
+func EncodeGRPCGetRulesForUserResponse(_ context.Context, response interface{}) (interface{}, error) {
+	res := response.(GetRulesForUserResponse)
+	rules := []pb.IPTRule{}
+
+	gRPCRes := &pb.GetRulesForUserResponse{}
+	if res.Error != nil {
+		gRPCRes.Error = res.Error.Error()
+	}
+
+	for _, v := range res.Rules {
+		rule := pb.IPTRule{
+			Operation:       v.Operation,
+			Target:          v.Target,
+			Chain:           v.Chain,
+			Protocol:        v.Protocol,
+			In:              v.In,
+			Out:             v.Out,
+			Source:          string(v.Source),
+			Destination:     string(v.Destination),
+			SourcePort:      uint32(v.SourcePort),
+			DestinationPort: uint32(v.DestinationPort),
+			State:           v.State,
+		}
+		rules = append(rules, rule)
+	}
+	gRPCRes.Rules = rules
+
+	return gRPCRes, nil
+}


### PR DESCRIPTION
This PR includes the implementation of the iptables service functions, the grpc transport and iptables client.

## Changes in `main.go`:
- Add the iptables service endpoints

## Changes in `messages/`:
- Add the iptables messages `iptables.proto` (resolves #147)

## Changes in `pkg/`
- Changes in `firewall/`: Adapt function definitions to use new `Inet` type
- Changes in `iptables/`:
  - Create a client (resolves #149)
  - Include an `Operation` field in the Rule struct in order to delete or append rules
  - Create iptables service endpoints
  - Implement `RemoveRule` function and create tests (resolve #140)
  - Adapt tests and rule functions to use the new `Operation` field
  - Implement `GetRulesForUser` function and create tests (resolve #141)
  - Create iptables grpc transport (resolves #148)
