### PR TITLE
Refactor refid to be a string (bridge name)

### DIFF
--- a/cmd/krood/main.go
+++ b/cmd/krood/main.go
@@ -300,15 +300,15 @@ func makeIPTServiceEndpoints(s iptables.Service) iptables.Endpoints {
 		RemoveRuleEndpoint = iptables.MakeRemoveRuleEndpoint(s)
 	}
 
-	var GetRulesForUserEndpoint endpoint.Endpoint
+	var GetRulesByRefEndpoint endpoint.Endpoint
 	{
-		GetRulesForUserEndpoint = iptables.MakeGetRulesForUserEndpoint(s)
+		GetRulesByRefEndpoint = iptables.MakeGetRulesByRefEndpoint(s)
 	}
 
 	return iptables.Endpoints{
-		AddRuleEndpoint:         AddRuleEndpoint,
-		RemoveRuleEndpoint:      RemoveRuleEndpoint,
-		GetRulesForUserEndpoint: GetRulesForUserEndpoint,
+		AddRuleEndpoint:       AddRuleEndpoint,
+		RemoveRuleEndpoint:    RemoveRuleEndpoint,
+		GetRulesByRefEndpoint: GetRulesByRefEndpoint,
 	}
 }
 

--- a/messages/iptables.proto
+++ b/messages/iptables.proto
@@ -4,7 +4,7 @@ package pb;
 service IPTablesService {
     rpc AddRule (AddRuleRequest) returns (AddRuleResponse);
     rpc RemoveRule (RemoveRuleRequest) returns (RemoveRuleResponse);
-    rpc GetRulesForUser (GetRulesForUserRequest) returns (GetRulesForUserResponse);
+    rpc GetRulesByRef (GetRulesByRefRequest) returns (GetRulesByRefResponse);
 }
 
 message IPTRule {
@@ -22,7 +22,7 @@ message IPTRule {
 }
 
 message AddRuleRequest {
-    uint32 Refid = 1;
+    string Refid = 1;
     IPTRule Rule = 2;
 }
 
@@ -38,11 +38,11 @@ message RemoveRuleResponse {
     string Error = 1;
 }
 
-message GetRulesForUserRequest {
-    uint32 Refid = 1;
+message GetRulesByRefRequest {
+    string Refid = 1;
 }
 
-message GetRulesForUserResponse {
+message GetRulesByRefResponse {
     repeated IPTRule Rules = 1;
     string error = 2;
 }

--- a/pkg/iptables/datatypes.go
+++ b/pkg/iptables/datatypes.go
@@ -20,6 +20,6 @@ type Rule struct {
 
 type iptablesEntry struct {
 	ID    string
-	Refid uint
+	Refid string
 	Rule
 }

--- a/pkg/iptables/endpoint.go
+++ b/pkg/iptables/endpoint.go
@@ -8,14 +8,14 @@ import (
 
 // Endpoints is a struct which collects all endpoints for the iptables service
 type Endpoints struct {
-	AddRuleEndpoint         endpoint.Endpoint
-	RemoveRuleEndpoint      endpoint.Endpoint
-	GetRulesForUserEndpoint endpoint.Endpoint
+	AddRuleEndpoint       endpoint.Endpoint
+	RemoveRuleEndpoint    endpoint.Endpoint
+	GetRulesByRefEndpoint endpoint.Endpoint
 }
 
 // AddRuleRequest is the request struct for the AddRuleEndpoint
 type AddRuleRequest struct {
-	Refid uint
+	Refid string
 	Rule  Rule
 }
 
@@ -56,23 +56,23 @@ func MakeRemoveRuleEndpoint(s Service) endpoint.Endpoint {
 	}
 }
 
-// GetRulesForUserRequest is the request struct for the GetRulesForUserEndpoint
-type GetRulesForUserRequest struct {
-	Refid uint
+// GetRulesByRefRequest is the request struct for the GetRulesByRefEndpoint
+type GetRulesByRefRequest struct {
+	Refid string
 }
 
-// GetRulesForUserResponse is the response struct for the GetRulesForUserEndpoint
-type GetRulesForUserResponse struct {
+// GetRulesByRefResponse is the response struct for the GetRulesByRefEndpoint
+type GetRulesByRefResponse struct {
 	Rules []Rule
 	Error error
 }
 
-// MakeGetRulesForUserEndpoint creates a gokit endpoint which invokes GetRulesForUser
-func MakeGetRulesForUserEndpoint(s Service) endpoint.Endpoint {
+// MakeGetRulesByRefEndpoint creates a gokit endpoint which invokes GetRulesByRef
+func MakeGetRulesByRefEndpoint(s Service) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
-		req := request.(GetRulesForUserRequest)
-		rules, err := s.GetRulesForUser(req.Refid)
-		return GetRulesForUserResponse{
+		req := request.(GetRulesByRefRequest)
+		rules, err := s.GetRulesByRef(req.Refid)
+		return GetRulesByRefResponse{
 			Rules: rules,
 			Error: err,
 		}, nil

--- a/pkg/iptables/iptables_test.go
+++ b/pkg/iptables/iptables_test.go
@@ -334,7 +334,7 @@ var _ = Describe("Iptables", func() {
 		It("Should add a rule", func() {
 			ipts, _ := iptables.NewService("iptables", testutils.NewMockDB())
 
-			err := ipts.AddRule(123, iptables.Rule{
+			err := ipts.AddRule("br-123", iptables.Rule{
 				Target:          "REDIRECT",
 				Chain:           "PREROUTING",
 				Protocol:        "tcp",
@@ -349,7 +349,7 @@ var _ = Describe("Iptables", func() {
 		It("Should error on invalid rule", func() {
 			ipts, _ := iptables.NewService("iptables", testutils.NewMockDB())
 
-			err := ipts.AddRule(123, iptables.Rule{
+			err := ipts.AddRule("br-123", iptables.Rule{
 				Target:          "FAIL",
 				Chain:           "PREROUTING",
 				Protocol:        "tcp",
@@ -364,7 +364,7 @@ var _ = Describe("Iptables", func() {
 		It("Should error on existing rule", func() {
 			ipts, _ := iptables.NewService("iptables", testutils.NewMockDB())
 
-			ipts.AddRule(123, iptables.Rule{
+			ipts.AddRule("br-123", iptables.Rule{
 				Target:          "REDIRECT",
 				Chain:           "PREROUTING",
 				Protocol:        "tcp",
@@ -373,7 +373,7 @@ var _ = Describe("Iptables", func() {
 				DestinationPort: 80,
 			})
 
-			err := ipts.AddRule(123, iptables.Rule{
+			err := ipts.AddRule("br-123", iptables.Rule{
 				Target:          "REDIRECT",
 				Chain:           "PREROUTING",
 				Protocol:        "tcp",
@@ -390,7 +390,7 @@ var _ = Describe("Iptables", func() {
 
 			iptablesIsPresent = 0
 
-			err := ipts.AddRule(123, iptables.Rule{
+			err := ipts.AddRule("br-123", iptables.Rule{
 				Target:          "REDIRECT",
 				Chain:           "PREROUTING",
 				Protocol:        "tcp",
@@ -418,7 +418,7 @@ var _ = Describe("Iptables", func() {
 				DestinationPort: 80,
 			}
 
-			ipts.AddRule(123, r)
+			ipts.AddRule("br-123", r)
 
 			hash = r.GetHash()
 			err := ipts.RemoveRule(hash)
@@ -445,9 +445,9 @@ var _ = Describe("Iptables", func() {
 				SourcePort:      8080,
 				DestinationPort: 80,
 			}
-			ipts.AddRule(123, r)
+			ipts.AddRule("br-123", r)
 
-			rules, err := ipts.GetRulesForUser(123)
+			rules, err := ipts.GetRulesByRef("br-123")
 
 			Ω(err).ShouldNot(HaveOccurred())
 			Ω(len(rules)).Should(Equal(1))
@@ -462,7 +462,7 @@ var _ = Describe("Iptables", func() {
 
 			db.SetError(1)
 
-			rules, err := ipts.GetRulesForUser(123)
+			rules, err := ipts.GetRulesByRef("br-123")
 
 			Ω(err).Should(HaveOccurred())
 			Ω(len(rules)).Should(Equal(0))

--- a/pkg/iptables/service.go
+++ b/pkg/iptables/service.go
@@ -11,11 +11,11 @@ import (
 // Service handles iptables rules
 type Service interface {
 	// AddRule adds a given iptables rule
-	AddRule(refid uint, rule Rule) error
+	AddRule(refid string, rule Rule) error
 	// RemoveRule removes a given iptables rule
 	RemoveRule(id string) error
-	// GetRulesForUser returns a list of all rules for a given user
-	GetRulesForUser(refid uint) ([]Rule, error)
+	// GetRulesByRef returns a list of all rules for a given reference
+	GetRulesByRef(refid string) ([]Rule, error)
 	// CreateIPTablesBackup creates an iptables backup file
 	CreateIPTablesBackup() string
 	// LoadIPTablesBackup restores iptables from backup file
@@ -59,7 +59,7 @@ func (s *service) ruleExists(r Rule) bool {
 	return false
 }
 
-func (s *service) AddRule(refid uint, rule Rule) error {
+func (s *service) AddRule(refid string, rule Rule) error {
 	r, err := rule.ToString()
 	if err != nil {
 		return err
@@ -118,7 +118,7 @@ func (s *service) RemoveRule(id string) error {
 	return nil
 }
 
-func (s *service) GetRulesForUser(refid uint) ([]Rule, error) {
+func (s *service) GetRulesByRef(refid string) ([]Rule, error) {
 	rules := []Rule{}
 	ipt := []iptablesEntry{}
 	err := s.db.Find(&ipt)

--- a/pkg/iptables/transport_grpc.go
+++ b/pkg/iptables/transport_grpc.go
@@ -29,19 +29,19 @@ func MakeGRPCServer(ctx context.Context, endpoints Endpoints, logger log.Logger)
 			EncodeGRPCRemoveRuleResponse,
 			options...,
 		),
-		getrulesforuser: grpctransport.NewServer(
-			endpoints.GetRulesForUserEndpoint,
-			DecodeGRPCGetRulesForUserRequest,
-			EncodeGRPCGetRulesForUserResponse,
+		getrulesbyref: grpctransport.NewServer(
+			endpoints.GetRulesByRefEndpoint,
+			DecodeGRPCGetRulesByRefRequest,
+			EncodeGRPCGetRulesByRefResponse,
 			options...,
 		),
 	}
 }
 
 type grpcServer struct {
-	addrule         grpctransport.Handler
-	removerule      grpctransport.Handler
-	getrulesforuser grpctransport.Handler
+	addrule       grpctransport.Handler
+	removerule    grpctransport.Handler
+	getrulesbyref grpctransport.Handler
 }
 
 func (s *grpcServer) AddRule(ctx oldcontext.Context, req *pb.AddRuleRequest) (*pb.AddRuleResponse, error) {
@@ -60,12 +60,12 @@ func (s *grpcServer) RemoveRule(ctx oldcontext.Context, req *pb.RemoveRuleReques
 	return res.(*pb.RemoveRuleResponse), nil
 }
 
-func (s *grpcServer) GetRulesForUser(ctx oldcontext.Context, req *pb.GetRulesForUserRequest) (*pb.GetRulesForUserResponse, error) {
-	_, res, err := s.getrulesforuser.ServeGRPC(ctx, req)
+func (s *grpcServer) GetRulesByRef(ctx oldcontext.Context, req *pb.GetRulesByRefRequest) (*pb.GetRulesByRefResponse, error) {
+	_, res, err := s.getrulesbyref.ServeGRPC(ctx, req)
 	if err != nil {
 		return nil, err
 	}
-	return res.(*pb.GetRulesForUserResponse), nil
+	return res.(*pb.GetRulesByRefResponse), nil
 }
 
 func convertToNativeRule(r pb.IPTRule) (Rule, error) {
@@ -104,7 +104,7 @@ func DecodeGRPCAddRuleRequest(_ context.Context, grpcReq interface{}) (interface
 	}
 
 	return AddRuleRequest{
-		Refid: uint(req.Refid),
+		Refid: req.Refid,
 		Rule:  rule,
 	}, nil
 }
@@ -118,12 +118,12 @@ func DecodeGRPCRemoveRuleRequest(_ context.Context, grpcReq interface{}) (interf
 	}, nil
 }
 
-// DecodeGRPCGetRulesForUserRequest is a transport/grpc.DecodeRequestFunc that converts a
-// gRPC GetRulesForUser request to a messages/iptables.proto-domain getrulesforuser request.
-func DecodeGRPCGetRulesForUserRequest(_ context.Context, grpcReq interface{}) (interface{}, error) {
-	req := grpcReq.(*pb.GetRulesForUserRequest)
-	return GetRulesForUserRequest{
-		Refid: uint(req.Refid),
+// DecodeGRPCGetRulesByRefRequest is a transport/grpc.DecodeRequestFunc that converts a
+// gRPC GetRulesByRef request to a messages/iptables.proto-domain GetRulesByRef request.
+func DecodeGRPCGetRulesByRefRequest(_ context.Context, grpcReq interface{}) (interface{}, error) {
+	req := grpcReq.(*pb.GetRulesByRefRequest)
+	return GetRulesByRefRequest{
+		Refid: req.Refid,
 	}, nil
 }
 
@@ -149,13 +149,13 @@ func EncodeGRPCRemoveRuleResponse(_ context.Context, response interface{}) (inte
 	return gRPCRes, nil
 }
 
-// EncodeGRPCGetRulesForUserResponse is a transport/grpc.EncodeRequestFunc that converts a
-// messages/iptables.proto-domain getrulesforuser response to a gRPC GetRulesForUser response.
-func EncodeGRPCGetRulesForUserResponse(_ context.Context, response interface{}) (interface{}, error) {
-	res := response.(GetRulesForUserResponse)
+// EncodeGRPCGetRulesByRefResponse is a transport/grpc.EncodeRequestFunc that converts a
+// messages/iptables.proto-domain GetRulesByRef response to a gRPC GetRulesByRef response.
+func EncodeGRPCGetRulesByRefResponse(_ context.Context, response interface{}) (interface{}, error) {
+	res := response.(GetRulesByRefResponse)
 	rules := []*pb.IPTRule{}
 
-	gRPCRes := &pb.GetRulesForUserResponse{}
+	gRPCRes := &pb.GetRulesByRefResponse{}
 	if res.Error != nil {
 		gRPCRes.Error = res.Error.Error()
 	}


### PR DESCRIPTION
This PR refactors the iptables service to not use a `uint` reference id but a string. Rules are now saved with respect to bridge interfaces and not user ids in order to prevent weird dependencies.