### PR TITLE
Add Routing Service Business Logic

### DIFF
--- a/pkg/abstraction/db.go
+++ b/pkg/abstraction/db.go
@@ -34,6 +34,7 @@ type DB interface {
 	GetValue() interface{}
 
 	AppendToArray(query interface{}, target string, values interface{}) error
+	RemoveFromArray(query interface{}, target string, index int) error
 
 	// Every function below invokes gorm.DB's function and returns gorm.DB's Error property
 	Begin()
@@ -61,61 +62,22 @@ func (w *dbWrapper) GetValue() interface{} {
 	return w.db.Value
 }
 
-func (w *dbWrapper) AppendToArray(elem interface{}, target string, value interface{}) error {
-	var (
-		tableName string
-		stringVal string
-		primary   []string
-		query     string
-		typeCast  string
-	)
-
-	v := reflect.ValueOf(elem)
-	if v.Kind() == reflect.Ptr {
-		v = v.Elem()
-	}
+func (w *dbWrapper) getTableName(v reflect.Value) string {
 	t := v.Type()
-
-	// check if target is field of reference type
-	f, isPart := t.FieldByName(strings.Title(target))
-	if !isPart {
-		return fmt.Errorf("%s is not a column in destination table", target)
-	}
-
-	tag := f.Tag.Get("sql")
-	re := regexp.MustCompile(`type:(.+)\[\]`)
-	match := re.FindStringSubmatch(tag)
-	if len(match) < 2 {
-		return fmt.Errorf("unsupported type %s", tag)
-	}
-	typeCast = match[1]
 
 	// Get TableName, either from type name or if it exists from TableName function
 	nameFunc, exists := t.MethodByName("TableName")
 	if exists {
 		nameResult := nameFunc.Func.Call([]reflect.Value{v})
-		tableName = nameResult[0].String()
-	} else {
-		tableName = gorm.ToDBName(t.Name())
+		return nameResult[0].String()
 	}
+	return gorm.ToDBName(t.Name())
+}
 
-	valuer, exists := reflect.TypeOf(value).MethodByName("Value")
+func (w *dbWrapper) generateWhereClause(query *string, v reflect.Value) error {
+	var primary []string
 
-	if exists {
-		valuerResult := valuer.Func.Call([]reflect.Value{reflect.ValueOf(value)})
-		stringVal = valuerResult[0].Interface().(string)
-	} else {
-		var ok bool
-		stringVal, ok = value.(string)
-		if !ok {
-			return errors.New("type not supported")
-		}
-	}
-
-	target = gorm.ToDBName(target)
-
-	// Set Update parameters
-	query = fmt.Sprintf("UPDATE %s SET %s = %s || $1::%s", tableName, target, target, typeCast)
+	t := v.Type()
 
 	// Search for primary keys in the reference type
 	idTag := "ID"
@@ -141,31 +103,120 @@ func (w *dbWrapper) AppendToArray(elem interface{}, target string, value interfa
 	}
 
 	// Set WHERE clause
-	query = fmt.Sprintf("%s WHERE", query)
+	*query = fmt.Sprintf("%s WHERE", *query)
 	for i, key := range primary {
 		if i > 0 {
-			query = fmt.Sprintf("%s AND", query)
+			*query = fmt.Sprintf("%s AND", *query)
 		}
 		value := v.FieldByName(key)
 		key = gorm.ToDBName(key)
 		k := value.Kind()
 		if k == reflect.String {
-			query = fmt.Sprintf("%s %s='%s'", query, key, value.String())
+			*query = fmt.Sprintf("%s %s='%s'", *query, key, value.String())
 		} else if k == reflect.Uint {
-			query = fmt.Sprintf("%s %s=%d", query, key, value.Uint())
+			*query = fmt.Sprintf("%s %s=%d", *query, key, value.Uint())
 		} else {
 			return fmt.Errorf("unexpected %s", k)
 		}
 
 	}
-	query = fmt.Sprintf("%s RETURNING cardinality(%s) AS index", query, target)
 
-	if w.tx != nil {
-		_, err := w.tx.CommonDB().Exec(query, stringVal)
+	return nil
+}
+
+func (w *dbWrapper) AppendToArray(elem interface{}, target string, value interface{}) error {
+	var (
+		tableName string
+		stringVal string
+		query     string
+		typeCast  string
+	)
+
+	v := reflect.ValueOf(elem)
+	if v.Kind() == reflect.Ptr {
+		v = v.Elem()
+	}
+	t := v.Type()
+
+	// check if target is field of reference type
+	f, isPart := t.FieldByName(strings.Title(target))
+	if !isPart {
+		return fmt.Errorf("%s is not a column in destination table", target)
+	}
+	target = gorm.ToDBName(target)
+
+	tag := f.Tag.Get("sql")
+	re := regexp.MustCompile(`type:(.+)\[\]`)
+	match := re.FindStringSubmatch(tag)
+	if len(match) < 2 {
+		return fmt.Errorf("unsupported type %s", tag)
+	}
+	typeCast = match[1]
+
+	tableName = w.getTableName(v)
+
+	valuer, exists := reflect.TypeOf(value).MethodByName("Value")
+
+	if exists {
+		valuerResult := valuer.Func.Call([]reflect.Value{reflect.ValueOf(value)})
+		stringVal = valuerResult[0].Interface().(string)
+	} else {
+		var ok bool
+		stringVal, ok = value.(string)
+		if !ok {
+			return errors.New("type not supported")
+		}
+	}
+
+	// Set Update parameters
+	query = fmt.Sprintf("UPDATE %s SET %s = %s || $1::%s", tableName, target, target, typeCast)
+
+	err := w.generateWhereClause(&query, v)
+	if err != nil {
 		return err
 	}
 
-	_, err := w.db.DB().Exec(query, stringVal)
+	query = fmt.Sprintf("%s RETURNING cardinality(%s) AS index", query, target)
+
+	if w.tx != nil {
+		_, err = w.tx.CommonDB().Exec(query, stringVal)
+		return err
+	}
+
+	_, err = w.db.DB().Exec(query, stringVal)
+	return err
+}
+
+func (w *dbWrapper) RemoveFromArray(elem interface{}, target string, index int) error {
+	var query string
+
+	v := reflect.ValueOf(elem)
+	if v.Kind() == reflect.Ptr {
+		v = v.Elem()
+	}
+	t := v.Type()
+
+	_, isPart := t.FieldByName(strings.Title(target))
+	if !isPart {
+		return fmt.Errorf("%s is not a column in destination table", target)
+	}
+	target = gorm.ToDBName(target)
+
+	tableName := w.getTableName(v)
+
+	query = fmt.Sprintf("UPDATE %s SET %s = array_remove(%s, %s[$1])", tableName, target, target, target)
+
+	err := w.generateWhereClause(&query, v)
+	if err != nil {
+		return err
+	}
+
+	if w.tx != nil {
+		_, err = w.tx.CommonDB().Exec(query, index)
+		return err
+	}
+
+	_, err = w.db.DB().Exec(query, index)
 	return err
 }
 

--- a/pkg/abstraction/db.go
+++ b/pkg/abstraction/db.go
@@ -6,7 +6,15 @@
 
 package abstraction
 
-import "github.com/jinzhu/gorm"
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"regexp"
+	"strings"
+
+	"github.com/jinzhu/gorm"
+)
 
 // DBAdapter includes functions used for Transactions and Getters
 type DBAdapter interface {
@@ -24,6 +32,8 @@ type DB interface {
 
 	// GetValue returns gorm.DB's Value property
 	GetValue() interface{}
+
+	AppendToArray(query interface{}, target string, values interface{}) error
 
 	// Every function below invokes gorm.DB's function and returns gorm.DB's Error property
 	Begin()
@@ -49,6 +59,114 @@ func (w *dbWrapper) GetAffectedRows() int64 {
 
 func (w *dbWrapper) GetValue() interface{} {
 	return w.db.Value
+}
+
+func (w *dbWrapper) AppendToArray(elem interface{}, target string, value interface{}) error {
+	var (
+		tableName string
+		stringVal string
+		primary   []string
+		query     string
+		typeCast  string
+	)
+
+	v := reflect.ValueOf(elem)
+	if v.Kind() == reflect.Ptr {
+		v = v.Elem()
+	}
+	t := v.Type()
+
+	// check if target is field of reference type
+	f, isPart := t.FieldByName(strings.Title(target))
+	if !isPart {
+		return fmt.Errorf("%s is not a column in destination table", target)
+	}
+
+	tag := f.Tag.Get("sql")
+	re := regexp.MustCompile(`type:(.+)\[\]`)
+	match := re.FindStringSubmatch(tag)
+	if len(match) < 2 {
+		return fmt.Errorf("unsupported type %s", tag)
+	}
+	typeCast = match[1]
+
+	// Get TableName, either from type name or if it exists from TableName function
+	nameFunc, exists := t.MethodByName("TableName")
+	if exists {
+		nameResult := nameFunc.Func.Call([]reflect.Value{v})
+		tableName = nameResult[0].String()
+	} else {
+		tableName = gorm.ToDBName(t.Name())
+	}
+
+	valuer, exists := reflect.TypeOf(value).MethodByName("Value")
+
+	if exists {
+		valuerResult := valuer.Func.Call([]reflect.Value{reflect.ValueOf(value)})
+		stringVal = valuerResult[0].Interface().(string)
+	} else {
+		var ok bool
+		stringVal, ok = value.(string)
+		if !ok {
+			return errors.New("type not supported")
+		}
+	}
+
+	target = gorm.ToDBName(target)
+
+	// Set Update parameters
+	query = fmt.Sprintf("UPDATE %s SET %s = %s || $1::%s", tableName, target, target, typeCast)
+
+	// Search for primary keys in the reference type
+	idTag := "ID"
+	_, found := t.FieldByName(idTag)
+	if found {
+		primary = append(primary, idTag)
+	}
+
+	primaryRegExp := regexp.MustCompile("primary_key")
+	for i := 0; i < t.NumField(); i++ {
+		f := t.Field(i)
+		v, ok := f.Tag.Lookup("gorm")
+		if ok {
+			isPrimary := primaryRegExp.MatchString(v)
+			if isPrimary {
+				primary = append(primary, f.Name)
+			}
+		}
+	}
+
+	if len(primary) == 0 {
+		return errors.New("no primary key found")
+	}
+
+	// Set WHERE clause
+	query = fmt.Sprintf("%s WHERE", query)
+	for i, key := range primary {
+		if i > 0 {
+			query = fmt.Sprintf("%s AND", query)
+		}
+		value := v.FieldByName(key)
+		key = gorm.ToDBName(key)
+		k := value.Kind()
+		if k == reflect.String {
+			query = fmt.Sprintf("%s %s='%s'", query, key, value.String())
+		} else if k == reflect.Uint {
+			query = fmt.Sprintf("%s %s=%d", query, key, value.Uint())
+		} else {
+			return fmt.Errorf("unexpected %s", k)
+		}
+
+	}
+	query = fmt.Sprintf("%s RETURNING cardinality(%s) AS index", query, target)
+
+	if w.tx != nil {
+		_, err := w.tx.CommonDB().Exec(query, stringVal)
+		return err
+	}
+
+	_, err := w.db.DB().Exec(query, stringVal)
+	return err
 }
 
 func (w *dbWrapper) Begin() {

--- a/pkg/routing/datatypes.go
+++ b/pkg/routing/datatypes.go
@@ -17,10 +17,68 @@ type ListenStatement struct {
 	keyword   string
 }
 
+// Scan implements the sql.Scanner interface.
+func (l *ListenStatement) Scan(src interface{}) error {
+	switch src := src.(type) {
+	case []byte:
+		return l.scanBytes(src)
+	case string:
+		return l.scanBytes([]byte(src))
+	case nil:
+		*l = ListenStatement{}
+		return nil
+	}
+
+	return fmt.Errorf("pq: cannot convert %T to Frontend Array", src)
+}
+
+func (l *ListenStatement) scanBytes(src []byte) error {
+	return json.Unmarshal(src, l)
+}
+
+// Value implements the driver.Valuer interface.
+func (l ListenStatement) Value() (driver.Value, error) {
+	if l == (ListenStatement{}) {
+		return nil, nil
+	}
+	b, err := json.Marshal(l)
+
+	return string(b), err
+}
+
 // Log combines a path and a keyword
 type Log struct {
 	path    string
 	keyword string
+}
+
+// Scan implements the sql.Scanner interface.
+func (l *Log) Scan(src interface{}) error {
+	switch src := src.(type) {
+	case []byte:
+		return l.scanBytes(src)
+	case string:
+		return l.scanBytes([]byte(src))
+	case nil:
+		*l = Log{}
+		return nil
+	}
+
+	return fmt.Errorf("pq: cannot convert %T to Frontend Array", src)
+}
+
+func (l *Log) scanBytes(src []byte) error {
+	return json.Unmarshal(src, l)
+}
+
+// Value implements the driver.Valuer interface.
+func (l Log) Value() (driver.Value, error) {
+	if l == (Log{}) {
+		return nil, nil
+	}
+	b, err := json.Marshal(l)
+
+	return string(b), err
 }
 
 // SSLSettings represents a set of configurations in terms of ssl transport
@@ -34,8 +92,39 @@ type SSLSettings struct {
 
 // LocationRule is a struct which combines a single location (URL path) with a set of rules
 type LocationRule struct {
-	location string
-	rules    map[string][]string
+	Location string
+	Rules    map[string][]string
+}
+
+// Scan implements the sql.Scanner interface.
+func (l *LocationRule) Scan(src interface{}) error {
+	switch src := src.(type) {
+	case []byte:
+		return l.scanBytes(src)
+	case string:
+		return l.scanBytes([]byte(src))
+	case nil:
+		*l = LocationRule{
+			Rules: make(map[string][]string),
+		}
+		return nil
+	}
+
+	return fmt.Errorf("pq: cannot convert %T to Frontend Array", src)
+}
+
+func (l *LocationRule) scanBytes(src []byte) error {
+	return json.Unmarshal(src, l)
+}
+
+// Value implements the driver.Valuer interface.
+func (l LocationRule) Value() (driver.Value, error) {
+	if l.Location == "" {
+		return nil, nil
+	}
+	b, err := json.Marshal(l)
+
+	return string(b), err
 }
 
 // LocationRules is an array of LocationRules
@@ -72,18 +161,18 @@ func (l LocationRules) Value() (driver.Value, error) {
 
 // The RouterConfig struct represents the collected information needed to configurate an http router
 type RouterConfig struct {
-	RefID           uint   `gorm:"primary_key"`
-	Name            string `gorm:"primary_key"`
-	ListenStatement ListenStatement
-	ServerName      pq.StringArray
-	AccessLog       Log
-	ErrorLog        Log
-	EootPath        string
-	SSLSettings     SSLSettings
-	LocationRules   LocationRules
+	RefID           uint            `gorm:"primary_key"`
+	Name            string          `gorm:"primary_key"`
+	ListenStatement ListenStatement `sql:"type:jsonb"`
+	ServerName      pq.StringArray  `sql:"type:text[]"`
+	AccessLog       Log             `sql:"type:jsonb"`
+	ErrorLog        Log             `sql:"type:jsonb"`
+	RootPath        string
+	SSLSettings     SSLSettings   `sql:"type:jsonb"`
+	LocationRules   LocationRules `sql:"type:jsonb[]"`
 }
 
 // TableName sets RouterConfig's database table name
 func (RouterConfig) TableName() string {
-	return "Routing"
+	return "routing"
 }

--- a/pkg/routing/datatypes.go
+++ b/pkg/routing/datatypes.go
@@ -1,0 +1,89 @@
+package routing
+
+import (
+	"database/sql/driver"
+	"encoding/json"
+	"fmt"
+
+	"github.com/lib/pq"
+)
+
+type inet string
+
+// ListenStatement combines an ipAddress with a port and a keyword
+type ListenStatement struct {
+	ipAddress inet `sql:"type:inet"`
+	port      int
+	keyword   string
+}
+
+// Log combines a path and a keyword
+type Log struct {
+	path    string
+	keyword string
+}
+
+// SSLSettings represents a set of configurations in terms of ssl transport
+type SSLSettings struct {
+	protocols           []string
+	ciphers             []string
+	preferServerCiphers string
+	certificate         string
+	certificateKey      string
+}
+
+// LocationRule is a struct which combines a single location (URL path) with a set of rules
+type LocationRule struct {
+	location string
+	rules    map[string][]string
+}
+
+// LocationRules is an array of LocationRules
+type LocationRules []*LocationRule
+
+// Scan implements the sql.Scanner interface.
+func (l *LocationRules) Scan(src interface{}) error {
+	switch src := src.(type) {
+	case []byte:
+		return l.scanBytes(src)
+	case string:
+		return l.scanBytes([]byte(src))
+	case nil:
+		*l = nil
+		return nil
+	}
+
+	return fmt.Errorf("pq: cannot convert %T to Frontend Array", src)
+}
+
+func (l *LocationRules) scanBytes(src []byte) error {
+	return json.Unmarshal(src, l)
+}
+
+// Value implements the driver.Valuer interface.
+func (l LocationRules) Value() (driver.Value, error) {
+	if l == nil {
+		return nil, nil
+	}
+	b, err := json.Marshal(l)
+
+	return string(b), err
+}
+
+// The RouterConfig struct represents the collected information needed to configurate an http router
+type RouterConfig struct {
+	RefID           uint   `gorm:"primary_key"`
+	Name            string `gorm:"primary_key"`
+	ListenStatement ListenStatement
+	ServerName      pq.StringArray
+	AccessLog       Log
+	ErrorLog        Log
+	EootPath        string
+	SSLSettings     SSLSettings
+	LocationRules   LocationRules
+}
+
+// TableName sets RouterConfig's database table name
+func (RouterConfig) TableName() string {
+	return "Routing"
+}

--- a/pkg/routing/datatypes.go
+++ b/pkg/routing/datatypes.go
@@ -12,9 +12,9 @@ type inet string
 
 // ListenStatement combines an ipAddress with a port and a keyword
 type ListenStatement struct {
-	ipAddress inet `sql:"type:inet"`
-	port      int
-	keyword   string
+	IPAddress inet `sql:"type:inet"`
+	Port      int
+	Keyword   string
 }
 
 // Scan implements the sql.Scanner interface.

--- a/pkg/routing/datatypes.go
+++ b/pkg/routing/datatypes.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/kontainerooo/kontainer.ooo/pkg/abstraction"
 	"github.com/lib/pq"
 )
 
@@ -12,8 +13,8 @@ type inet string
 
 // ListenStatement combines an ipAddress with a port and a keyword
 type ListenStatement struct {
-	IPAddress inet `sql:"type:inet"`
-	Port      int
+	IPAddress abstraction.Inet `sql:"type:inet"`
+	Port      uint16
 	Keyword   string
 }
 

--- a/pkg/routing/routing_suite_test.go
+++ b/pkg/routing/routing_suite_test.go
@@ -1,0 +1,13 @@
+package routing_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestRouting(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Routing Suite")
+}

--- a/pkg/routing/routing_test.go
+++ b/pkg/routing/routing_test.go
@@ -1,0 +1,52 @@
+package routing_test
+
+import (
+	"github.com/kontainerooo/kontainer.ooo/pkg/routing"
+	"github.com/kontainerooo/kontainer.ooo/pkg/testutils"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Routing", func() {
+	Describe("Create Service", func() {
+		It("Should create service", func() {
+			routingService, err := routing.NewService(testutils.NewMockDB())
+			Ω(err).ShouldNot(HaveOccurred())
+			Expect(routingService).ToNot(BeZero())
+		})
+
+		It("Should return db error", func() {
+			db := testutils.NewMockDB()
+			db.SetError(1)
+			_, err := routing.NewService(db)
+			Ω(err).Should(HaveOccurred())
+		})
+	})
+
+	Describe("Create Router Config", func() {
+		db := testutils.NewMockDB()
+		routingService, _ := routing.NewService(db)
+		It("Should create RouterConfig with new RefID Name Pair", func() {
+			err := routingService.CreateRouterConfig(&routing.RouterConfig{
+				RefID: 0,
+				Name:  "test",
+			})
+			Ω(err).ShouldNot(HaveOccurred())
+		})
+
+		It("Should not create RouterConfig if RefID Name Pair already exists", func() {
+			err := routingService.CreateRouterConfig(&routing.RouterConfig{
+				RefID: 0,
+				Name:  "test",
+			})
+			Ω(err).Should(HaveOccurred())
+		})
+
+		It("Should return error on db failure", func() {
+			db.SetError(2)
+			err := routingService.CreateRouterConfig(&routing.RouterConfig{})
+			Ω(err).Should(HaveOccurred())
+		})
+	})
+})

--- a/pkg/routing/routing_test.go
+++ b/pkg/routing/routing_test.go
@@ -218,7 +218,7 @@ var _ = Describe("Routing", func() {
 		db := testutils.NewMockDB()
 		routingService, _ := routing.NewService(db)
 		It("Should change User Config", func() {
-			refID, name, port := uint(1), "test", 80
+			refID, name, port := uint(1), "test", uint16(80)
 			routingService.CreateRouterConfig(&routing.RouterConfig{
 				RefID: refID,
 				Name:  name,

--- a/pkg/routing/routing_test.go
+++ b/pkg/routing/routing_test.go
@@ -54,33 +54,65 @@ var _ = Describe("Routing", func() {
 		db := testutils.NewMockDB()
 		routingService, _ := routing.NewService(db)
 		It("Should change Router Config", func() {
-			refID, name := uint(0), "test"
+			refID, name := uint(1), "test"
 			routingService.CreateRouterConfig(&routing.RouterConfig{
 				RefID: refID,
 				Name:  name,
 			})
 
-			name = "test2"
+			newName := "test2"
 			err := routingService.EditRouterConfig(refID, name, &routing.RouterConfig{
-				Name: name,
+				Name: newName,
 			})
 			Ω(err).ShouldNot(HaveOccurred())
+
+			conf := &routing.RouterConfig{}
+			routingService.GetRouterConfig(refID, newName, conf)
+			Expect(conf.Name).To(BeEquivalentTo(newName))
 		})
 
 		It("Should prevent from changing the refID", func() {
-			err := routingService.EditRouterConfig(0, "test2", &routing.RouterConfig{
-				RefID: 1,
+			err := routingService.EditRouterConfig(1, "test2", &routing.RouterConfig{
+				RefID: 2,
 			})
 			Ω(err).Should(HaveOccurred())
 		})
 
 		It("Should return error on db failure", func() {
 			db.SetError(1)
-			err := routingService.EditRouterConfig(0, "", &routing.RouterConfig{})
+			err := routingService.EditRouterConfig(1, "", &routing.RouterConfig{})
 			Ω(err).Should(HaveOccurred())
 
 			db.SetError(2)
-			err = routingService.EditRouterConfig(0, "", &routing.RouterConfig{})
+			err = routingService.EditRouterConfig(1, "", &routing.RouterConfig{})
+			Ω(err).Should(HaveOccurred())
+		})
+	})
+
+	Describe("GetRouterConfig", func() {
+		db := testutils.NewMockDB()
+		routingService, _ := routing.NewService(db)
+		It("Should fill RouterConfig struct", func() {
+			refID, name := uint(1), "test"
+			routingService.CreateRouterConfig(&routing.RouterConfig{
+				RefID: refID,
+				Name:  name,
+			})
+
+			conf := &routing.RouterConfig{}
+			err := routingService.GetRouterConfig(refID, name, conf)
+			Ω(err).ShouldNot(HaveOccurred())
+			Expect(conf.Name).To(BeEquivalentTo(name))
+		})
+
+		It("Should return error if ID does not exist", func() {
+			err := routingService.GetRouterConfig(28, "", &routing.RouterConfig{})
+			Ω(err).Should(BeEquivalentTo(testutils.ErrNotFound))
+		})
+
+		It("Should return error on db failure", func() {
+			db.SetError(1)
+			err := routingService.GetRouterConfig(1, "", &routing.RouterConfig{})
 			Ω(err).Should(HaveOccurred())
 		})
 	})

--- a/pkg/routing/routing_test.go
+++ b/pkg/routing/routing_test.go
@@ -49,4 +49,39 @@ var _ = Describe("Routing", func() {
 			Ω(err).Should(HaveOccurred())
 		})
 	})
+
+	Describe("Edit Router Config", func() {
+		db := testutils.NewMockDB()
+		routingService, _ := routing.NewService(db)
+		It("Should change Router Config", func() {
+			refID, name := uint(0), "test"
+			routingService.CreateRouterConfig(&routing.RouterConfig{
+				RefID: refID,
+				Name:  name,
+			})
+
+			name = "test2"
+			err := routingService.EditRouterConfig(refID, name, &routing.RouterConfig{
+				Name: name,
+			})
+			Ω(err).ShouldNot(HaveOccurred())
+		})
+
+		It("Should prevent from changing the refID", func() {
+			err := routingService.EditRouterConfig(0, "test2", &routing.RouterConfig{
+				RefID: 1,
+			})
+			Ω(err).Should(HaveOccurred())
+		})
+
+		It("Should return error on db failure", func() {
+			db.SetError(1)
+			err := routingService.EditRouterConfig(0, "", &routing.RouterConfig{})
+			Ω(err).Should(HaveOccurred())
+
+			db.SetError(2)
+			err = routingService.EditRouterConfig(0, "", &routing.RouterConfig{})
+			Ω(err).Should(HaveOccurred())
+		})
+	})
 })

--- a/pkg/routing/routing_test.go
+++ b/pkg/routing/routing_test.go
@@ -305,4 +305,18 @@ var _ = Describe("Routing", func() {
 			Ω(err).Should(HaveOccurred())
 		})
 	})
+
+	Describe("Configurations", func() {
+		It("Should return all configurations", func() {
+			routingService, _ := routing.NewService(testutils.NewMockDB())
+			routingService.CreateRouterConfig(&routing.RouterConfig{
+				RefID: 1,
+				Name:  "test",
+			})
+
+			conf := make([]routing.RouterConfig, 0)
+			routingService.Configurations(&conf)
+			Expect(conf).To(HaveLen(1))
+		})
+	})
 })

--- a/pkg/routing/routing_test.go
+++ b/pkg/routing/routing_test.go
@@ -214,6 +214,37 @@ var _ = Describe("Routing", func() {
 		})
 	})
 
+	Describe("Change Listen Statement", func() {
+		db := testutils.NewMockDB()
+		routingService, _ := routing.NewService(db)
+		It("Should change User Config", func() {
+			refID, name, port := uint(1), "test", 80
+			routingService.CreateRouterConfig(&routing.RouterConfig{
+				RefID: refID,
+				Name:  name,
+			})
+
+			err := routingService.ChangeListenStatement(refID, name, &routing.ListenStatement{
+				Port: port,
+			})
+			Ω(err).ShouldNot(HaveOccurred())
+
+			conf := &routing.RouterConfig{}
+			routingService.GetRouterConfig(refID, name, conf)
+			Expect(conf.ListenStatement.Port).To(BeEquivalentTo(port))
+		})
+
+		It("Should return error on db failure", func() {
+			db.SetError(1)
+			err := routingService.ChangeListenStatement(1, "", nil)
+			Ω(err).Should(HaveOccurred())
+
+			db.SetError(2)
+			err = routingService.ChangeListenStatement(1, "", &routing.ListenStatement{})
+			Ω(err).Should(HaveOccurred())
+		})
+	})
+
 	Describe("AddServerName", func() {
 		db := testutils.NewMockDB()
 		routingService, _ := routing.NewService(db)

--- a/pkg/routing/routing_test.go
+++ b/pkg/routing/routing_test.go
@@ -213,4 +213,65 @@ var _ = Describe("Routing", func() {
 			Ω(err).Should(HaveOccurred())
 		})
 	})
+
+	Describe("AddServerName", func() {
+		db := testutils.NewMockDB()
+		routingService, _ := routing.NewService(db)
+		It("Should add a ServerName", func() {
+			refID, name := uint(1), "test"
+			routingService.CreateRouterConfig(&routing.RouterConfig{
+				RefID: refID,
+				Name:  name,
+			})
+
+			err := routingService.AddServerName(refID, name, "test")
+			Ω(err).ShouldNot(HaveOccurred())
+
+			conf := &routing.RouterConfig{}
+			routingService.GetRouterConfig(refID, name, conf)
+			Expect(conf.ServerName).To(HaveLen(1))
+		})
+
+		It("Should return error if ID does not exist", func() {
+			err := routingService.AddServerName(28, "", "")
+			Ω(err).Should(BeEquivalentTo(testutils.ErrNotFound))
+		})
+
+		It("Should return error on db failure", func() {
+			db.SetError(1)
+			err := routingService.AddServerName(1, "", "")
+			Ω(err).Should(HaveOccurred())
+		})
+	})
+
+	Describe("RemoveServerName", func() {
+		db := testutils.NewMockDB()
+		routingService, _ := routing.NewService(db)
+		It("Should add a LocationRule", func() {
+			refID, name := uint(1), "test"
+			routingService.CreateRouterConfig(&routing.RouterConfig{
+				RefID:      refID,
+				Name:       name,
+				ServerName: []string{"test"},
+			})
+
+			err := routingService.RemoveServerName(refID, name, 0)
+			Ω(err).ShouldNot(HaveOccurred())
+
+			conf := &routing.RouterConfig{}
+			routingService.GetRouterConfig(refID, name, conf)
+			Expect(conf.LocationRules).To(HaveLen(0))
+		})
+
+		It("Should return error if ID does not exist", func() {
+			err := routingService.RemoveServerName(28, "", 28)
+			Ω(err).Should(BeEquivalentTo(testutils.ErrNotFound))
+		})
+
+		It("Should return error on db failure", func() {
+			db.SetError(1)
+			err := routingService.RemoveServerName(1, "", 0)
+			Ω(err).Should(HaveOccurred())
+		})
+	})
 })

--- a/pkg/routing/routing_test.go
+++ b/pkg/routing/routing_test.go
@@ -146,4 +146,71 @@ var _ = Describe("Routing", func() {
 			Ω(err).Should(HaveOccurred())
 		})
 	})
+
+	Describe("AddLocationRule", func() {
+		db := testutils.NewMockDB()
+		routingService, _ := routing.NewService(db)
+		It("Should add a LocationRule", func() {
+			refID, name := uint(1), "test"
+			routingService.CreateRouterConfig(&routing.RouterConfig{
+				RefID: refID,
+				Name:  name,
+			})
+
+			err := routingService.AddLocationRule(refID, name, &routing.LocationRule{
+				Location: "/",
+			})
+			Ω(err).ShouldNot(HaveOccurred())
+
+			conf := &routing.RouterConfig{}
+			routingService.GetRouterConfig(refID, name, conf)
+			Expect(conf.LocationRules).To(HaveLen(1))
+		})
+
+		It("Should return error if ID does not exist", func() {
+			err := routingService.AddLocationRule(28, "", &routing.LocationRule{})
+			Ω(err).Should(BeEquivalentTo(testutils.ErrNotFound))
+		})
+
+		It("Should return error on db failure", func() {
+			db.SetError(1)
+			err := routingService.AddLocationRule(1, "", &routing.LocationRule{})
+			Ω(err).Should(HaveOccurred())
+		})
+	})
+
+	Describe("RemoveLocationRule", func() {
+		db := testutils.NewMockDB()
+		routingService, _ := routing.NewService(db)
+		It("Should add a LocationRule", func() {
+			refID, name := uint(1), "test"
+			routingService.CreateRouterConfig(&routing.RouterConfig{
+				RefID: refID,
+				Name:  name,
+				LocationRules: routing.LocationRules{
+					&routing.LocationRule{
+						Location: "/",
+					},
+				},
+			})
+
+			err := routingService.RemoveLocationRule(refID, name, 0)
+			Ω(err).ShouldNot(HaveOccurred())
+
+			conf := &routing.RouterConfig{}
+			routingService.GetRouterConfig(refID, name, conf)
+			Expect(conf.LocationRules).To(HaveLen(0))
+		})
+
+		It("Should return error if ID does not exist", func() {
+			err := routingService.RemoveLocationRule(28, "", 28)
+			Ω(err).Should(BeEquivalentTo(testutils.ErrNotFound))
+		})
+
+		It("Should return error on db failure", func() {
+			db.SetError(1)
+			err := routingService.RemoveLocationRule(1, "", 0)
+			Ω(err).Should(HaveOccurred())
+		})
+	})
 })

--- a/pkg/routing/routing_test.go
+++ b/pkg/routing/routing_test.go
@@ -116,4 +116,34 @@ var _ = Describe("Routing", func() {
 			Ω(err).Should(HaveOccurred())
 		})
 	})
+
+	Describe("DeleteRouterconfig", func() {
+		db := testutils.NewMockDB()
+		routingService, _ := routing.NewService(db)
+		It("Should remove RouterConfig from DB", func() {
+			refID, name := uint(1), "test"
+			routingService.CreateRouterConfig(&routing.RouterConfig{
+				RefID: refID,
+				Name:  name,
+			})
+			err := routingService.RemoveRouterConfig(refID, name)
+			Ω(err).ShouldNot(HaveOccurred())
+		})
+
+		It("Should return error on db failure", func() {
+			refID, name := uint(1), "test"
+			routingService.CreateRouterConfig(&routing.RouterConfig{
+				RefID: refID,
+				Name:  name,
+			})
+			db.SetError(1)
+			err := routingService.RemoveRouterConfig(refID, name)
+			Ω(err).Should(HaveOccurred())
+		})
+
+		It("Should return error if refID and/or name are not set", func() {
+			err := routingService.RemoveRouterConfig(0, "")
+			Ω(err).Should(HaveOccurred())
+		})
+	})
 })

--- a/pkg/routing/service.go
+++ b/pkg/routing/service.go
@@ -28,13 +28,13 @@ type Service interface {
 	RemoveLocationRule(refID uint, name string, lid int) error
 
 	// Chante the listen statement of a configuration by id, update file and router
-	ChangeListenStatement(id uint, ls *ListenStatement) error
+	ChangeListenStatement(refID uint, name string, ls *ListenStatement) error
 
 	// Add something to the server name of a configuration by id, update file and router
-	AddServerName(RefID uint, name string, sn string) error
+	AddServerName(refID uint, name string, sn string) error
 
 	// Add something to the server name of a configuration by id, update file and router
-	RemoveServerName(RefID uint, name string, id int) error
+	RemoveServerName(refID uint, name string, id int) error
 
 	// Configuration returns all Configurations
 	Configurations() []RouterConfig
@@ -157,8 +157,18 @@ func (s *service) RemoveLocationRule(refID uint, name string, lid int) error {
 	return nil
 }
 
-func (s *service) ChangeListenStatement(id uint, ls *ListenStatement) error {
-	// TODO: implement
+func (s *service) ChangeListenStatement(refID uint, name string, ls *ListenStatement) error {
+	err := s.db.Where("RefID = ? AND Name = ?", refID, name)
+	if err != nil {
+		return err
+	}
+
+	err = s.db.Update(&RouterConfig{}, &RouterConfig{
+		ListenStatement: *ls,
+	})
+	if err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/pkg/routing/service.go
+++ b/pkg/routing/service.go
@@ -19,7 +19,7 @@ type Service interface {
 	GetRouterConfig(refID uint, name string, r *RouterConfig) error
 
 	// Remove a configuration by id, remove file, update router
-	RemoveRouterConfig(id uint) error
+	RemoveRouterConfig(refID uint, name string) error
 
 	// Add a location rule to a configuration by id, update file and router
 	AddLocationRule(id uint, lr *LocationRule) (int, error)
@@ -44,6 +44,7 @@ type dbAdapter interface {
 	First(interface{}, ...interface{}) error
 	Create(interface{}) error
 	Update(interface{}, ...interface{}) error
+	Delete(interface{}, ...interface{}) error
 }
 
 type service struct {
@@ -108,9 +109,15 @@ func (s *service) GetRouterConfig(refID uint, name string, r *RouterConfig) erro
 	return nil
 }
 
-func (s *service) RemoveRouterConfig(id uint) error {
-	// TODO: implement
-	return nil
+func (s *service) RemoveRouterConfig(refID uint, name string) error {
+	if refID == 0 || name == "" {
+		return errors.New("refID and name have to be set")
+	}
+
+	return s.db.Delete(&RouterConfig{
+		RefID: refID,
+		Name:  name,
+	})
 }
 
 func (s *service) AddLocationRule(id uint, lr *LocationRule) (int, error) {

--- a/pkg/routing/service.go
+++ b/pkg/routing/service.go
@@ -25,7 +25,7 @@ type Service interface {
 	AddLocationRule(refID uint, name string, lr *LocationRule) error
 
 	// Remove a location rule by its id in a configuration by id, update file and router
-	RemoveLocationRule(id uint, lid int) error
+	RemoveLocationRule(refID uint, name string, lid int) error
 
 	// Chante the listen statement of a configuration by id, update file and router
 	ChangeListenStatement(id uint, ls *ListenStatement) error
@@ -46,6 +46,7 @@ type dbAdapter interface {
 	Update(interface{}, ...interface{}) error
 	Delete(interface{}, ...interface{}) error
 	AppendToArray(interface{}, string, interface{}) error
+	RemoveFromArray(interface{}, string, int) error
 }
 
 type service struct {
@@ -137,8 +138,19 @@ func (s *service) AddLocationRule(refID uint, name string, lr *LocationRule) err
 	return nil
 }
 
-func (s *service) RemoveLocationRule(id uint, lid int) error {
-	// TODO: implement
+func (s *service) RemoveLocationRule(refID uint, name string, lid int) error {
+	s.db.Begin()
+
+	err := s.db.RemoveFromArray(&RouterConfig{
+		RefID: refID,
+		Name:  name,
+	}, "LocationRules", lid)
+	if err != nil {
+		s.db.Rollback()
+		return err
+	}
+
+	s.db.Commit()
 	return nil
 }
 

--- a/pkg/routing/service.go
+++ b/pkg/routing/service.go
@@ -37,7 +37,7 @@ type Service interface {
 	RemoveServerName(refID uint, name string, id int) error
 
 	// Configuration returns all Configurations
-	Configurations() []RouterConfig
+	Configurations(r *[]RouterConfig)
 }
 
 type dbAdapter interface {
@@ -45,6 +45,7 @@ type dbAdapter interface {
 	AutoMigrate(...interface{}) error
 	Where(interface{}, ...interface{}) error
 	First(interface{}, ...interface{}) error
+	Find(interface{}, ...interface{}) error
 	Create(interface{}) error
 	Update(interface{}, ...interface{}) error
 	Delete(interface{}, ...interface{}) error
@@ -204,9 +205,8 @@ func (s *service) RemoveServerName(refID uint, name string, id int) error {
 	return nil
 }
 
-func (s *service) Configurations() []RouterConfig {
-	// TODO: implement
-	return nil
+func (s *service) Configurations(r *[]RouterConfig) {
+	s.db.Find(r)
 }
 
 // NewService creates a UserService with necessary dependencies.

--- a/pkg/routing/service.go
+++ b/pkg/routing/service.go
@@ -30,8 +30,11 @@ type Service interface {
 	// Chante the listen statement of a configuration by id, update file and router
 	ChangeListenStatement(id uint, ls *ListenStatement) error
 
-	// Change the server name(s) of a configuration by id, update file and router
-	ChangeServerName(id uint, sn []string) error
+	// Add something to the server name of a configuration by id, update file and router
+	AddServerName(RefID uint, name string, sn string) error
+
+	// Add something to the server name of a configuration by id, update file and router
+	RemoveServerName(RefID uint, name string, id int) error
 
 	// Configuration returns all Configurations
 	Configurations() []RouterConfig
@@ -159,8 +162,35 @@ func (s *service) ChangeListenStatement(id uint, ls *ListenStatement) error {
 	return nil
 }
 
-func (s *service) ChangeServerName(id uint, sn []string) error {
-	// TODO: implement
+func (s *service) AddServerName(refID uint, name string, sn string) error {
+	s.db.Begin()
+
+	err := s.db.AppendToArray(&RouterConfig{
+		RefID: refID,
+		Name:  name,
+	}, "ServerName", sn)
+	if err != nil {
+		s.db.Rollback()
+		return err
+	}
+
+	s.db.Commit()
+	return nil
+}
+
+func (s *service) RemoveServerName(refID uint, name string, id int) error {
+	s.db.Begin()
+
+	err := s.db.RemoveFromArray(&RouterConfig{
+		RefID: refID,
+		Name:  name,
+	}, "ServerName", id)
+	if err != nil {
+		s.db.Rollback()
+		return err
+	}
+
+	s.db.Commit()
 	return nil
 }
 

--- a/pkg/routing/service.go
+++ b/pkg/routing/service.go
@@ -1,0 +1,97 @@
+package routing
+
+import "github.com/kontainerooo/kontainer.ooo/pkg/abstraction"
+
+// The Service interface describes the functions necessary for kontainer.ooo routing service
+type Service interface {
+	// Insert a new configuration into the DB, write to a file, update the router
+	CreateRouterConfig(r *RouterConfig) (uint, error)
+
+	// Edit an existing configuration by id, update file and router
+	EditRouterConfig(id uint, r *RouterConfig) error
+
+	// Remove a configuration by id, remove file, update router
+	RemoveRouterConfig(id uint) error
+
+	// Add a location rule to a configuration by id, update file and router
+	AddLocationRule(id uint, lr *LocationRule) (int, error)
+
+	// Remove a location rule by its id in a configuration by id, update file and router
+	RemoveLocationRule(id uint, lid int) error
+
+	// Chante the listen statement of a configuration by id, update file and router
+	ChangeListenStatement(id uint, ls *ListenStatement) error
+
+	// Change the server name(s) of a configuration by id, update file and router
+	ChangeServerName(id uint, sn []string) error
+
+	// Configuration returns all Configurations
+	Configurations() []RouterConfig
+}
+
+type dbAdapter interface {
+	abstraction.DBAdapter
+	AutoMigrate(...interface{}) error
+}
+
+type service struct {
+	db dbAdapter
+}
+
+func (s service) InitializeDatabases() error {
+	return s.db.AutoMigrate(&RouterConfig{})
+}
+
+func (s *service) CreateRouterConfig(r *RouterConfig) (uint, error) {
+	// TODO: implement
+	return 0, nil
+}
+
+func (s *service) EditRouterConfig(id uint, r *RouterConfig) error {
+	// TODO: implement
+	return nil
+}
+
+func (s *service) RemoveRouterConfig(id uint) error {
+	// TODO: implement
+	return nil
+}
+
+func (s *service) AddLocationRule(id uint, lr *LocationRule) (int, error) {
+	// TODO: implement
+	return 0, nil
+}
+
+func (s *service) RemoveLocationRule(id uint, lid int) error {
+	// TODO: implement
+	return nil
+}
+
+func (s *service) ChangeListenStatement(id uint, ls *ListenStatement) error {
+	// TODO: implement
+	return nil
+}
+
+func (s *service) ChangeServerName(id uint, sn []string) error {
+	// TODO: implement
+	return nil
+}
+
+func (s *service) Configurations() []RouterConfig {
+	// TODO: implement
+	return nil
+}
+
+// NewService creates a UserService with necessary dependencies.
+func NewService(db dbAdapter) (Service, error) {
+	s := &service{
+		db: db,
+	}
+
+	err := s.InitializeDatabases()
+	if err != nil {
+		return nil, err
+	}
+
+	return s, nil
+}

--- a/pkg/testutils/mockdb.go
+++ b/pkg/testutils/mockdb.go
@@ -271,12 +271,17 @@ func (m *MockDB) Delete(value interface{}, where ...interface{}) error {
 	if m.produceError() {
 		return ErrDBFailure
 	}
+	ids := make(map[string]reflect.Value)
+
 	ref := reflect.TypeOf(value).Elem()
 	name := ref.String()
 	table := m.tables[name]
-	id := reflect.ValueOf(value).Elem().FieldByName(table.PrimaryKey)
-	if id != RNil {
-		return m.tables[name].delete(id)
+	for _, k := range table.PrimaryKey {
+		ids[k] = reflect.ValueOf(value).Elem().FieldByName(k)
+	}
+
+	if len(ids) != 0 {
+		return m.tables[name].delete(ids)
 	}
 	return ErrDBFailure
 }

--- a/pkg/testutils/mockdb.go
+++ b/pkg/testutils/mockdb.go
@@ -80,6 +80,35 @@ func (m *MockDB) PrintTables() {
 	}
 }
 
+// AppendToArray append to array
+func (m *MockDB) AppendToArray(query interface{}, target string, values interface{}) error {
+	if m.produceError() {
+		return ErrDBFailure
+	}
+	v := reflect.ValueOf(query).Elem()
+	t := v.Type()
+	name := t.String()
+	table, ok := m.tables[name]
+	if !ok {
+		return errors.New("table does not exist")
+	}
+
+	return table.appendToArray(v, target, values)
+}
+
+// RemoveFromArray remove from array
+func (m *MockDB) RemoveFromArray(query interface{}, target string, index int) error {
+	v := reflect.ValueOf(query).Elem()
+	t := v.Type()
+	name := t.String()
+	table, ok := m.tables[name]
+	if !ok {
+		return errors.New("table does not exist")
+	}
+
+	return table.removeFromArray(v, target, index)
+}
+
 // Begin begin transaction
 func (m *MockDB) Begin() {
 	m.rollback = make(map[string]*table)

--- a/pkg/testutils/testutils.go
+++ b/pkg/testutils/testutils.go
@@ -3,14 +3,16 @@ package testutils
 import (
 	"errors"
 	"reflect"
+	"regexp"
 )
 
 func merge(dst, src reflect.Value, overwriteID bool, depth int) error {
 	if depth > 7 {
 		return errors.New("too deep")
 	}
+	idRegexp := regexp.MustCompile("ID")
 	for i := 0; i < src.NumField(); i++ {
-		if !overwriteID && src.Type().Field(i).Name == "ID" {
+		if !overwriteID && idRegexp.MatchString(src.Type().Field(i).Name) {
 			continue
 		}
 


### PR DESCRIPTION
This pull request adds the routing service business logic including datatypes and tests.

- Changes in *pkg*
  - Add Routing Service
  - Add Service Interface (Resolves #115) and implementation of:
    - CreateRouterConfig (Resolves #116)
    - EditRouterConfig (Resolves #117)
    - GetRouterConfig
    - RemoveRouterConfig (Resolves #118)
    - AddLocationRule (Resolves #119)
    - RemoveLocationRule (Resolves #120)
    - AddServerName
    - RemoveServerName (Resolves #122)
    - ChangeListenStatement (Resolves #121)
    - Configurations (Resolves #123)
  - Add Datatypes used for Router Configuration (Resolves #113)
  - Add AppendToArray and RemoveFromArray in abstraction.DB and testutils.MockDB

Thanks to Laura for this:
![b1080a4c-66f5-423e-88c5-afdb9c6433ec](https://cloud.githubusercontent.com/assets/10075040/24375412/737d8582-1338-11e7-91c1-dbdfefd519c0.jpeg)
