### PR TITLE
Fix docker daemon configuration

### DIFF
--- a/scripts/daemon.json
+++ b/scripts/daemon.json
@@ -1,4 +1,3 @@
 {
-    "iptables": false,
-    "icc": false
+    "iptables": false
 }


### PR DESCRIPTION
Remove the `icc` option since `icc` uses iptables in order to achieve
preventing inter container communication. So obviously it cannot be used
together with `"iptables": false`.