### PR TITLE
Firewall service and iptables nat

### DIFF
--- a/pkg/firewall/firewall_test.go
+++ b/pkg/firewall/firewall_test.go
@@ -1,6 +1,9 @@
 package firewall_test
 
 import (
+	"os"
+	"testing"
+
 	"github.com/kontainerooo/kontainer.ooo/pkg/abstraction"
 	"github.com/kontainerooo/kontainer.ooo/pkg/firewall"
 	"github.com/kontainerooo/kontainer.ooo/pkg/testutils"
@@ -8,10 +11,19 @@ import (
 	. "github.com/onsi/gomega"
 )
 
+// TestHelperProcess Mocks the iptables binary
+func TestHelperProcess(t *testing.T) {
+	if os.Getenv("GO_WANT_HELPER_PROCESS") != "1" {
+		return
+	}
+
+	os.Exit(0)
+}
+
 var _ = Describe("Firewall", func() {
 	Describe("Create Service", func() {
 		It("Should create a new service", func() {
-			mockIpt := testutils.NewMockIPTService()
+			mockIpt, _ := testutils.NewMockIPTService()
 
 			fws, err := firewall.NewService(mockIpt)
 
@@ -22,11 +34,11 @@ var _ = Describe("Firewall", func() {
 
 	Describe("Init bridge", func() {
 		It("Should set up rules for bridge initialisation", func() {
-			mockIpt := testutils.NewMockIPTService()
+			mockIpt, _ := testutils.NewMockIPTService()
 
 			fws, _ := firewall.NewService(mockIpt)
 
-			ip, _ := abstraction.NewInet("0.0.0.0/0")
+			ip, _ := abstraction.NewInet("172.18.0.0/16")
 			err := fws.InitBridge(ip, "br-084d60eeada1")
 
 			Ω(err).ShouldNot(HaveOccurred())

--- a/pkg/firewall/iptables/datatypes.go
+++ b/pkg/firewall/iptables/datatypes.go
@@ -80,7 +80,7 @@ var (
 	isolationRuleStr = fmt.Sprintf("-A %s ! -i {{.SrcNetwork}} -o {{.SrcNetwork}} -j DROP", IptIsolationChain)
 
 	outgoingOutRuleStr = fmt.Sprintf("-A %s -s {{.SrcIP}} ! -d 172.16.0.0/12 -i {{.SrcNetwork}} ! -o {{.SrcNetwork}} -j ACCEPT", IptOutboundChain)
-	outgoingInRuleStr  = fmt.Sprintf("-A %s ! -s 172.16.0.0/12 - d {{.SrcIP}} ! -i {{.SrcNetwork}} -o {{.SrcNetwork}} -j ACCEPT", IptOutboundChain)
+	outgoingInRuleStr  = fmt.Sprintf("-A %s ! -s 172.16.0.0/12 -d {{.SrcIP}} ! -i {{.SrcNetwork}} -o {{.SrcNetwork}} -j ACCEPT", IptOutboundChain)
 
 	linkContainerPortToStr   = fmt.Sprintf("-A %s -s {{.SrcIP}} -d {{.DstIP}} -i {{.SrcNetwork}} -o {{.DstNetwork}} -p {{.Protocol}} --dport {{.DstPort}} -j ACCEPT", IptLinkChain)
 	linkContainerPortFromStr = fmt.Sprintf("-A %s -s {{.DstIP}} -d {{.SrcIP}} -i {{.DstNetwork}} -o {{.SrcNetwork}} -p {{.Protocol}} -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT", IptLinkChain)
@@ -94,9 +94,9 @@ var (
 	allowPortInStr  = "-A {{.Chain}} -p {{.Protocol}} -m {{.Protocol}} --sport {{.Port}} -m state --state ESTABLISHED -j ACCEPT"
 	allowPortOutStr = "-A {{.Chain}} -p {{.Protocol}} -m {{.Protocol}} --dport {{.Port}} -m state --state NEW,ESTABLISHED -j ACCEPT"
 
-	natOutStr = fmt.Sprintf("-A OUTPUT ! -d 127.0.0.0/8 -m addrtype --dst-type LOCAL -j %s", IptNatChain)
+	natOutStr = fmt.Sprintf("-t nat -A OUTPUT ! -d 127.0.0.0/8 -m addrtype --dst-type LOCAL -j %s", IptNatChain)
 
-	natMaskStr = "-A POSTROUTING -s {{.SrcIP}} ! -o {{.SrcNetwork}} -j MASQUERADE"
+	natMaskStr = "-t nat -A POSTROUTING -s {{.SrcIP}} ! -o {{.SrcNetwork}} -j MASQUERADE"
 )
 
 var (
@@ -143,7 +143,7 @@ var (
 	NatOutRuleTmpl = template.Must(template.New("natOutRule").Parse(natOutStr))
 
 	// NatMaskRuleTmpl is the template for the nat outgoing mask rule
-	NatMaskRuleTmpl = template.Must(template.New("natMaskRule").Parse(natOutStr))
+	NatMaskRuleTmpl = template.Must(template.New("natMaskRule").Parse(natMaskStr))
 )
 
 // RuleEntry represents a database rule entry

--- a/pkg/firewall/iptables/datatypes.go
+++ b/pkg/firewall/iptables/datatypes.go
@@ -69,7 +69,7 @@ const (
 var (
 	createChainRuleStr = "-t {{.Table}} -N {{.Name}}"
 
-	jumpToChainRuleStr = "-t {{.Table}} -A {{.From}} {{if .SrcNetwork}} -i {{.SrcNetwork}} {{end}} -j {{.To}}"
+	jumpToChainRuleStr = "-t {{.Table}} -A {{.From}} {{if .SrcNetwork}} -i {{.SrcNetwork}} {{end}} {{if .Match}} -m {{.Match}} {{end}} -j {{.To}}"
 
 	isolationRuleStr = fmt.Sprintf("-A %s ! -i {{.SrcNetwork}} -o {{.SrcNetwork}} -j DROP", IptIsolationChain)
 
@@ -369,6 +369,7 @@ type JumpToChainRule struct {
 	To         string
 	Table      string
 	SrcNetwork string
+	Match      string
 }
 
 // IsolationRule represents rule data for an IsolationRuleType

--- a/pkg/firewall/iptables/datatypes.go
+++ b/pkg/firewall/iptables/datatypes.go
@@ -24,6 +24,9 @@ const (
 	// IptOutboundChain is the name of the outbound chain
 	IptOutboundChain = "KROO-OUTBOUND"
 
+	// IptNatChain is the name of the custom chain that is used within the nat table
+	IptNatChain = "KROO-NAT"
+
 	// CreateChainRuleType specifies a CreateChainRule
 	CreateChainRuleType = iota
 
@@ -64,7 +67,7 @@ const (
 )
 
 var (
-	createChainRuleStr = "-N {{.Name}}"
+	createChainRuleStr = "-t {{.Table}} -N {{.Name}}"
 
 	jumpToChainRuleStr = "-A {{.From}} -j {{.To}}"
 
@@ -190,7 +193,8 @@ func (r *Rule) scanBytes(src []byte) error {
 	switch a.RuleType {
 	case CreateChainRuleType:
 		r.Data = CreateChainRule{
-			Name: data.Name,
+			Name:  data.Name,
+			Table: data.Table,
 		}
 	case JumpToChainRuleType:
 		r.Data = JumpToChainRule{
@@ -349,11 +353,13 @@ type anyRule struct {
 	DstPort    float64
 	Port       float64
 	Chain      string
+	Table      string
 }
 
 // CreateChainRule represents rule data for a CreateChainRuleType
 type CreateChainRule struct {
-	Name string
+	Name  string
+	Table string
 }
 
 // JumpToChainRule represents rule data for a JumpToChainRuleType

--- a/pkg/firewall/iptables/datatypes.go
+++ b/pkg/firewall/iptables/datatypes.go
@@ -69,7 +69,7 @@ const (
 var (
 	createChainRuleStr = "-t {{.Table}} -N {{.Name}}"
 
-	jumpToChainRuleStr = "-A {{.From}} -j {{.To}}"
+	jumpToChainRuleStr = "-t {{.Table}} -A {{.From}} -j {{.To}}"
 
 	isolationRuleStr = fmt.Sprintf("-A %s ! -i {{.SrcNetwork}} -o {{.SrcNetwork}} -j DROP", IptIsolationChain)
 
@@ -198,8 +198,9 @@ func (r *Rule) scanBytes(src []byte) error {
 		}
 	case JumpToChainRuleType:
 		r.Data = JumpToChainRule{
-			From: data.From,
-			To:   data.To,
+			From:  data.From,
+			To:    data.To,
+			Table: data.Table,
 		}
 	case IsolationRuleType:
 		r.Data = IsolationRule{
@@ -364,8 +365,9 @@ type CreateChainRule struct {
 
 // JumpToChainRule represents rule data for a JumpToChainRuleType
 type JumpToChainRule struct {
-	From string
-	To   string
+	From  string
+	To    string
+	Table string
 }
 
 // IsolationRule represents rule data for an IsolationRuleType

--- a/pkg/firewall/iptables/datatypes.go
+++ b/pkg/firewall/iptables/datatypes.go
@@ -69,7 +69,7 @@ const (
 var (
 	createChainRuleStr = "-t {{.Table}} -N {{.Name}}"
 
-	jumpToChainRuleStr = "-t {{.Table}} -A {{.From}} -j {{.To}}"
+	jumpToChainRuleStr = "-t {{.Table}} -A {{.From}} {{if .SrcNetwork}} -i {{.SrcNetwork}} {{end}} -j {{.To}}"
 
 	isolationRuleStr = fmt.Sprintf("-A %s ! -i {{.SrcNetwork}} -o {{.SrcNetwork}} -j DROP", IptIsolationChain)
 
@@ -365,9 +365,10 @@ type CreateChainRule struct {
 
 // JumpToChainRule represents rule data for a JumpToChainRuleType
 type JumpToChainRule struct {
-	From  string
-	To    string
-	Table string
+	From       string
+	To         string
+	Table      string
+	SrcNetwork string
 }
 
 // IsolationRule represents rule data for an IsolationRuleType

--- a/pkg/firewall/iptables/iptables_test.go
+++ b/pkg/firewall/iptables/iptables_test.go
@@ -68,7 +68,8 @@ var _ = Describe("Iptables", func() {
 			ipts, _ := iptables.NewService("iptables", testutils.NewMockDB())
 
 			err := ipts.CreateRule(iptables.CreateChainRuleType, iptables.CreateChainRule{
-				Name: "KROO-TEST",
+				Name:  "KROO-TEST",
+				Table: "nat",
 			})
 
 			Ω(err).ShouldNot(HaveOccurred())

--- a/pkg/firewall/iptables/iptables_test.go
+++ b/pkg/firewall/iptables/iptables_test.go
@@ -222,5 +222,24 @@ var _ = Describe("Iptables", func() {
 
 			Ω(err).ShouldNot(HaveOccurred())
 		})
+
+		It("Should create a new NatOutRule", func() {
+			ipts, _ := iptables.NewService("iptables", testutils.NewMockDB())
+
+			err := ipts.CreateRule(iptables.NatOutRuleType, iptables.NatOutRule{})
+
+			Ω(err).ShouldNot(HaveOccurred())
+		})
+
+		It("Should create a new NatMaskRule", func() {
+			ipts, _ := iptables.NewService("iptables", testutils.NewMockDB())
+
+			err := ipts.CreateRule(iptables.NatMaskRuleType, iptables.NatMaskRule{
+				SrcIP:      simpleNewInet("127.0.0.1"),
+				SrcNetwork: "br-0815",
+			})
+
+			Ω(err).ShouldNot(HaveOccurred())
+		})
 	})
 })

--- a/pkg/firewall/iptables/service.go
+++ b/pkg/firewall/iptables/service.go
@@ -358,7 +358,7 @@ func (s *service) CreateRule(ruleType int, ruleData interface{}) error {
 			RuleType: NatMaskRuleType,
 		}
 		re.rule = rule
-		re.setRefs("", "", abstraction.Inet(""), abstraction.Inet(""))
+		re.setRefs(rd.SrcNetwork, "", rd.SrcIP, abstraction.Inet(""))
 
 		var buf bytes.Buffer
 		err := NatMaskRuleTmpl.Execute(&buf, rd)

--- a/pkg/firewall/iptables/service.go
+++ b/pkg/firewall/iptables/service.go
@@ -67,6 +67,9 @@ func (s *service) CreateRule(ruleType int, ruleData interface{}) error {
 		if !ok {
 			return errInvalidData
 		}
+		if rd.Table == "" {
+			rd.Table = "filter"
+		}
 		rule := Rule{
 			Data:     rd,
 			RuleType: CreateChainRuleType,
@@ -86,6 +89,9 @@ func (s *service) CreateRule(ruleType int, ruleData interface{}) error {
 		rd, ok := ruleData.(JumpToChainRule)
 		if !ok {
 			return errInvalidData
+		}
+		if rd.Table == "" {
+			rd.Table = "filter"
 		}
 		rule := Rule{
 			Data:     rd,

--- a/pkg/firewall/iptables/service.go
+++ b/pkg/firewall/iptables/service.go
@@ -328,6 +328,46 @@ func (s *service) CreateRule(ruleType int, ruleData interface{}) error {
 
 		cmdStr = buf.String()
 		re.ID = createHash(cmdStr)
+	case NatOutRuleType:
+		rd, ok := ruleData.(NatOutRule)
+		if !ok {
+			return errInvalidData
+		}
+		rule := Rule{
+			Data:     rd,
+			RuleType: NatOutRuleType,
+		}
+		re.rule = rule
+		re.setRefs("", "", abstraction.Inet(""), abstraction.Inet(""))
+
+		var buf bytes.Buffer
+		err := NatOutRuleTmpl.Execute(&buf, rd)
+		if err != nil {
+			return err
+		}
+
+		cmdStr = buf.String()
+		re.ID = createHash(cmdStr)
+	case NatMaskRuleType:
+		rd, ok := ruleData.(NatMaskRule)
+		if !ok {
+			return errInvalidData
+		}
+		rule := Rule{
+			Data:     rd,
+			RuleType: NatMaskRuleType,
+		}
+		re.rule = rule
+		re.setRefs("", "", abstraction.Inet(""), abstraction.Inet(""))
+
+		var buf bytes.Buffer
+		err := NatMaskRuleTmpl.Execute(&buf, rd)
+		if err != nil {
+			return err
+		}
+
+		cmdStr = buf.String()
+		re.ID = createHash(cmdStr)
 	default:
 		return errors.New("pq: cannot convert input src to FrontendArray")
 	}

--- a/pkg/testutils/mockIPT.go
+++ b/pkg/testutils/mockIPT.go
@@ -1,20 +1,44 @@
 package testutils
 
-import "github.com/kontainerooo/kontainer.ooo/pkg/firewall/iptables"
+import (
+	"os"
+	"os/exec"
+
+	"github.com/kontainerooo/kontainer.ooo/pkg/firewall/iptables"
+)
 
 // MockIPTService simulates a iptables service for testing purposes
 type MockIPTService struct {
 	rules map[string]iptables.RuleEntry
+	s     iptables.Service
+}
+
+func fakeExecCommand(command string, args ...string) *exec.Cmd {
+	cs := []string{"-test.run=TestHelperProcess", "--", command}
+	cs = append(cs, args...)
+	cmd := exec.Command(os.Args[0], cs...)
+	cmd.Env = []string{"GO_WANT_HELPER_PROCESS=1"}
+	return cmd
 }
 
 // CreateRule creates a new iptables rule
 func (m *MockIPTService) CreateRule(ruleType int, ruleData interface{}) error {
-	return nil
+	return m.s.CreateRule(ruleType, ruleData)
+}
+
+// ListRules lists all created rules as string
+func (m *MockIPTService) ListRules() []string {
+	return []string{}
 }
 
 // NewMockIPTService creates a new MockIPTServicet
-func NewMockIPTService() *MockIPTService {
+func NewMockIPTService() (*MockIPTService, error) {
+	db := NewMockDB()
+	iptables.ExecCommand = fakeExecCommand
+	ipts, err := iptables.NewService("iptables", db)
+
 	return &MockIPTService{
 		rules: make(map[string]iptables.RuleEntry),
-	}
+		s:     ipts,
+	}, err
 }


### PR DESCRIPTION
This PR adds nat rules for the iptables service. In this stage the firewall service can now set up the standard rules to isolate containers from each other and allow them to only connect to the internet.

Resolves #156 

Changes in `pkg/`:
- Changes in `firewall/`:
  - Create firewall tests with mock iptables service
  - Fix iptables set up mistakes (wrong order for chains etc.)
- Changes in `firewall/iptables`:
  - Introduce nat rules
  - Fix template errors
- Changes in `testutils`
  - Create a working iptables service mock