### PR TITLE
Firewall and container to container connection

### DIFF
--- a/messages/firewall.proto
+++ b/messages/firewall.proto
@@ -1,0 +1,68 @@
+syntax = "proto3";
+package firewall;
+option go_package = "pb";
+
+service FirewallService {
+	rpc InitBridge (InitBridgeRequest) returns (InitBridgeResponse);
+	rpc AllowConnection (AllowConnectionRequest) returns (AllowConnectionResponse);
+	rpc BlockConnection (BlockConnectionRequest) returns (BlockConnectionResponse);
+	rpc AllowPort (AllowPortRequest) returns (AllowPortResponse);
+	rpc BlockPort (BlockPortRequest) returns (BlockPortResponse);
+}
+
+message InitBridgeRequest {
+    string IP = 1;
+    string networkName = 2;
+}
+
+message InitBridgeResponse {
+    string error = 1;
+}
+
+message AllowConnectionRequest {
+    string srcIP = 1;
+    string srcNetwork = 2;
+    string dstIP = 3;
+    string dstNetwork = 4;
+}
+
+message AllowConnectionResponse {
+    string error = 1;
+}
+
+message BlockConnectionRequest {
+    string srcIP = 1;
+    string srcNetwork = 2;
+    string dstIP = 3;
+    string dstNetwork = 4;
+}
+
+message BlockConnectionResponse {
+    string error = 1;
+}
+
+message AllowPortRequest {
+    string srcIP = 1;
+    string srcNetwork = 2;
+    string dstIP = 3;
+    string dstNetwork = 4;
+    uint32 port = 5;
+    string protocol = 6;
+}
+
+message AllowPortResponse {
+    string error = 1;
+}
+
+message BlockPortRequest {
+    string srcIP = 1;
+    string srcNetwork = 2;
+    string dstIP = 3;
+    string dstNetwork = 4;
+    uint32 port = 5;
+    string protocol = 6;
+}
+
+message BlockPortResponse {
+    string error = 1;
+}

--- a/pkg/firewall/client/client.go
+++ b/pkg/firewall/client/client.go
@@ -1,0 +1,195 @@
+package client
+
+import (
+	"context"
+	"errors"
+
+	"github.com/go-kit/kit/endpoint"
+	"github.com/go-kit/kit/log"
+	grpctransport "github.com/go-kit/kit/transport/grpc"
+	"google.golang.org/grpc"
+
+	"github.com/kontainerooo/kontainer.ooo/pkg/firewall"
+	"github.com/kontainerooo/kontainer.ooo/pkg/pb"
+)
+
+// New creates a set of endpoints based on a gRPC connection
+func New(conn *grpc.ClientConn, logger log.Logger) *firewall.Endpoints {
+	var InitBridgeEndpoint endpoint.Endpoint
+	{
+		InitBridgeEndpoint = grpctransport.NewClient(
+			conn,
+			"firewallService",
+			"InitBridge",
+			EncodeGRPCInitBridgeRequest,
+			DecodeGRPCInitBridgeResponse,
+			pb.InitBridgeResponse{},
+		).Endpoint()
+	}
+	var AllowConnectionEndpoint endpoint.Endpoint
+	{
+		AllowConnectionEndpoint = grpctransport.NewClient(
+			conn,
+			"firewallService",
+			"AllowConnection",
+			EncodeGRPCAllowConnectionRequest,
+			DecodeGRPCAllowConnectionResponse,
+			pb.AllowConnectionResponse{},
+		).Endpoint()
+	}
+	var BlockConnectionEndpoint endpoint.Endpoint
+	{
+		BlockConnectionEndpoint = grpctransport.NewClient(
+			conn,
+			"firewallService",
+			"BlockConnection",
+			EncodeGRPCBlockConnectionRequest,
+			DecodeGRPCBlockConnectionResponse,
+			pb.BlockConnectionResponse{},
+		).Endpoint()
+	}
+	var AllowPortEndpoint endpoint.Endpoint
+	{
+		AllowPortEndpoint = grpctransport.NewClient(
+			conn,
+			"firewallService",
+			"AllowPort",
+			EncodeGRPCAllowPortRequest,
+			DecodeGRPCAllowPortResponse,
+			pb.AllowPortResponse{},
+		).Endpoint()
+	}
+	var BlockPortEndpoint endpoint.Endpoint
+	{
+		BlockPortEndpoint = grpctransport.NewClient(
+			conn,
+			"firewallService",
+			"BlockPort",
+			EncodeGRPCBlockPortRequest,
+			DecodeGRPCBlockPortResponse,
+			pb.BlockPortResponse{},
+		).Endpoint()
+	}
+
+	return &firewall.Endpoints{
+		InitBridgeEndpoint:      InitBridgeEndpoint,
+		AllowConnectionEndpoint: AllowConnectionEndpoint,
+		BlockConnectionEndpoint: BlockConnectionEndpoint,
+		AllowPortEndpoint:       AllowPortEndpoint,
+		BlockPortEndpoint:       BlockPortEndpoint,
+	}
+}
+
+func getError(e string) error {
+	if e != "" {
+		return errors.New(e)
+	}
+	return nil
+}
+
+// EncodeGRPCInitBridgeRequest is a transport/grpc.EncodeRequestFunc that converts a
+// messages/firewall.proto-domain initbridge request to a gRPC InitBridge request.
+func EncodeGRPCInitBridgeRequest(_ context.Context, request interface{}) (interface{}, error) {
+	req := request.(*firewall.InitBridgeRequest)
+	return &pb.InitBridgeRequest{
+		IP:          string(req.IP),
+		NetworkName: req.NetIf,
+	}, nil
+}
+
+// DecodeGRPCInitBridgeResponse is a transport/grpc.DecodeResponseFunc that converts a
+// gRPC InitBridge response to a messages/firewall.proto-domain initbridge response.
+func DecodeGRPCInitBridgeResponse(_ context.Context, grpcResponse interface{}) (interface{}, error) {
+	response := grpcResponse.(*pb.InitBridgeResponse)
+	return &firewall.InitBridgeResponse{
+		Error: getError(response.Error),
+	}, nil
+}
+
+// EncodeGRPCAllowConnectionRequest is a transport/grpc.EncodeRequestFunc that converts a
+// messages/firewall.proto-domain allowconnection request to a gRPC AllowConnection request.
+func EncodeGRPCAllowConnectionRequest(_ context.Context, request interface{}) (interface{}, error) {
+	req := request.(*firewall.AllowConnectionRequest)
+	return &pb.AllowConnectionRequest{
+		SrcIP:      string(req.SrcIP),
+		DstIP:      string(req.DstIP),
+		SrcNetwork: req.SrcNetwork,
+		DstNetwork: req.DstNetwork,
+	}, nil
+}
+
+// DecodeGRPCAllowConnectionResponse is a transport/grpc.DecodeResponseFunc that converts a
+// gRPC AllowConnection response to a messages/firewall.proto-domain allowconnection response.
+func DecodeGRPCAllowConnectionResponse(_ context.Context, grpcResponse interface{}) (interface{}, error) {
+	response := grpcResponse.(*pb.AllowConnectionResponse)
+	return &firewall.AllowConnectionResponse{
+		Error: getError(response.Error),
+	}, nil
+}
+
+// EncodeGRPCBlockConnectionRequest is a transport/grpc.EncodeRequestFunc that converts a
+// messages/firewall.proto-domain blockconnection request to a gRPC BlockConnection request.
+func EncodeGRPCBlockConnectionRequest(_ context.Context, request interface{}) (interface{}, error) {
+	req := request.(*firewall.BlockConnectionRequest)
+	return &pb.BlockConnectionRequest{
+		SrcIP:      string(req.SrcIP),
+		DstIP:      string(req.DstIP),
+		SrcNetwork: req.SrcNetwork,
+		DstNetwork: req.DstNetwork,
+	}, nil
+}
+
+// DecodeGRPCBlockConnectionResponse is a transport/grpc.DecodeResponseFunc that converts a
+// gRPC BlockConnection response to a messages/firewall.proto-domain blockconnection response.
+func DecodeGRPCBlockConnectionResponse(_ context.Context, grpcResponse interface{}) (interface{}, error) {
+	response := grpcResponse.(*pb.BlockConnectionResponse)
+	return &firewall.BlockConnectionResponse{
+		Error: getError(response.Error),
+	}, nil
+}
+
+// EncodeGRPCAllowPortRequest is a transport/grpc.EncodeRequestFunc that converts a
+// messages/firewall.proto-domain allowport request to a gRPC AllowPort request.
+func EncodeGRPCAllowPortRequest(_ context.Context, request interface{}) (interface{}, error) {
+	req := request.(*firewall.AllowPortRequest)
+	return &pb.AllowPortRequest{
+		SrcIP:      string(req.SrcIP),
+		DstIP:      string(req.DstIP),
+		SrcNetwork: req.SrcNetwork,
+		DstNetwork: req.DstNetwork,
+		Protocol:   req.Protocol,
+		Port:       uint32(req.Port),
+	}, nil
+}
+
+// DecodeGRPCAllowPortResponse is a transport/grpc.DecodeResponseFunc that converts a
+// gRPC AllowPort response to a messages/firewall.proto-domain allowport response.
+func DecodeGRPCAllowPortResponse(_ context.Context, grpcResponse interface{}) (interface{}, error) {
+	response := grpcResponse.(*pb.AllowPortResponse)
+	return &firewall.AllowPortResponse{
+		Error: getError(response.Error),
+	}, nil
+}
+
+// EncodeGRPCBlockPortRequest is a transport/grpc.EncodeRequestFunc that converts a
+// messages/firewall.proto-domain blockport request to a gRPC BlockPort request.
+func EncodeGRPCBlockPortRequest(_ context.Context, request interface{}) (interface{}, error) {
+	req := request.(*firewall.BlockPortRequest)
+	return &pb.BlockPortRequest{
+		SrcIP:      string(req.SrcIP),
+		DstIP:      string(req.DstIP),
+		SrcNetwork: req.SrcNetwork,
+		DstNetwork: req.DstNetwork,
+		Protocol:   req.Protocol,
+		Port:       uint32(req.Port),
+	}, nil
+}
+
+// DecodeGRPCBlockPortResponse is a transport/grpc.DecodeResponseFunc that converts a
+// gRPC BlockPort response to a messages/firewall.proto-domain blockport response.
+func DecodeGRPCBlockPortResponse(_ context.Context, grpcResponse interface{}) (interface{}, error) {
+	response := grpcResponse.(*pb.BlockPortResponse)
+	return &firewall.BlockPortResponse{
+		Error: getError(response.Error),
+	}, nil
+}

--- a/pkg/firewall/endpoint.go
+++ b/pkg/firewall/endpoint.go
@@ -88,12 +88,12 @@ func MakeBlockConnectionEndpoint(s Service) endpoint.Endpoint {
 
 // AllowPortRequest is the request struct for the AllowPortEndpoint
 type AllowPortRequest struct {
-	SrcIP    abstraction.Inet
-	SrcNw    string
-	DstIP    abstraction.Inet
-	DstNw    string
-	Port     uint16
-	Protocol string
+	SrcIP      abstraction.Inet
+	SrcNetwork string
+	DstIP      abstraction.Inet
+	DstNetwork string
+	Port       uint16
+	Protocol   string
 }
 
 // AllowPortResponse is the response struct for the AllowPortEndpoint
@@ -114,12 +114,12 @@ func MakeAllowPortEndpoint(s Service) endpoint.Endpoint {
 
 // BlockPortRequest is the request struct for the BlockPortEndpoint
 type BlockPortRequest struct {
-	SrcIP    abstraction.Inet
-	SrcNw    string
-	DstIP    abstraction.Inet
-	DstNw    string
-	Port     uint16
-	Protocol string
+	SrcIP      abstraction.Inet
+	SrcNetwork string
+	DstIP      abstraction.Inet
+	DstNetwork string
+	Port       uint16
+	Protocol   string
 }
 
 // BlockPortResponse is the response struct for the BlockPortEndpoint

--- a/pkg/firewall/endpoint.go
+++ b/pkg/firewall/endpoint.go
@@ -1,0 +1,139 @@
+package firewall
+
+import (
+	"context"
+
+	"github.com/go-kit/kit/endpoint"
+	"github.com/kontainerooo/kontainer.ooo/pkg/abstraction"
+)
+
+// Endpoints is a struct which collects all endpoints for the firewall service
+type Endpoints struct {
+	InitBridgeEndpoint      endpoint.Endpoint
+	AllowConnectionEndpoint endpoint.Endpoint
+	BlockConnectionEndpoint endpoint.Endpoint
+	AllowPortEndpoint       endpoint.Endpoint
+	BlockPortEndpoint       endpoint.Endpoint
+}
+
+// InitBridgeRequest is the request struct for the InitBridgeEndpoint
+type InitBridgeRequest struct {
+	IP    abstraction.Inet
+	NetIf string
+}
+
+// InitBridgeResponse is the response struct for the InitBridgeEndpoint
+type InitBridgeResponse struct {
+	Error error
+}
+
+// MakeInitBridgeEndpoint creates a gokit endpoint which invokes InitBridge
+func MakeInitBridgeEndpoint(s Service) endpoint.Endpoint {
+	return func(ctx context.Context, request interface{}) (interface{}, error) {
+		req := request.(InitBridgeRequest)
+		err := s.InitBridge(req.IP, req.NetIf)
+		return InitBridgeResponse{
+			Error: err,
+		}, nil
+	}
+}
+
+// AllowConnectionRequest is the request struct for the AllowConnectionEndpoint
+type AllowConnectionRequest struct {
+	SrcIP      abstraction.Inet
+	SrcNetwork string
+	DstIP      abstraction.Inet
+	DstNetwork string
+}
+
+// AllowConnectionResponse is the response struct for the AllowConnectionEndpoint
+type AllowConnectionResponse struct {
+	Error error
+}
+
+// MakeAllowConnectionEndpoint creates a gokit endpoint which invokes AllowConnection
+func MakeAllowConnectionEndpoint(s Service) endpoint.Endpoint {
+	return func(ctx context.Context, request interface{}) (interface{}, error) {
+		req := request.(AllowConnectionRequest)
+		err := s.AllowConnection(req.SrcIP, req.SrcNetwork, req.DstIP, req.DstNetwork)
+		return AllowConnectionResponse{
+			Error: err,
+		}, nil
+	}
+}
+
+// BlockConnectionRequest is the request struct for the BlockConnectionEndpoint
+type BlockConnectionRequest struct {
+	SrcIP      abstraction.Inet
+	SrcNetwork string
+	DstIP      abstraction.Inet
+	DstNetwork string
+}
+
+// BlockConnectionResponse is the response struct for the BlockConnectionEndpoint
+type BlockConnectionResponse struct {
+	Error error
+}
+
+// MakeBlockConnectionEndpoint creates a gokit endpoint which invokes BlockConnection
+func MakeBlockConnectionEndpoint(s Service) endpoint.Endpoint {
+	return func(ctx context.Context, request interface{}) (interface{}, error) {
+		req := request.(BlockConnectionRequest)
+		err := s.BlockConnection(req.SrcIP, req.SrcNetwork, req.DstIP, req.DstNetwork)
+		return BlockConnectionResponse{
+			Error: err,
+		}, nil
+	}
+}
+
+// AllowPortRequest is the request struct for the AllowPortEndpoint
+type AllowPortRequest struct {
+	SrcIP    abstraction.Inet
+	SrcNw    string
+	DstIP    abstraction.Inet
+	DstNw    string
+	Port     uint16
+	Protocol string
+}
+
+// AllowPortResponse is the response struct for the AllowPortEndpoint
+type AllowPortResponse struct {
+	Error error
+}
+
+// MakeAllowPortEndpoint creates a gokit endpoint which invokes AllowPort
+func MakeAllowPortEndpoint(s Service) endpoint.Endpoint {
+	return func(ctx context.Context, request interface{}) (interface{}, error) {
+		req := request.(AllowPortRequest)
+		err := s.AllowPort(req.SrcIP, req.SrcNetwork, req.DstIP, req.DstNetwork, req.Port, req.Protocol)
+		return AllowPortResponse{
+			Error: err,
+		}, nil
+	}
+}
+
+// BlockPortRequest is the request struct for the BlockPortEndpoint
+type BlockPortRequest struct {
+	SrcIP    abstraction.Inet
+	SrcNw    string
+	DstIP    abstraction.Inet
+	DstNw    string
+	Port     uint16
+	Protocol string
+}
+
+// BlockPortResponse is the response struct for the BlockPortEndpoint
+type BlockPortResponse struct {
+	Error error
+}
+
+// MakeBlockPortEndpoint creates a gokit endpoint which invokes BlockPort
+func MakeBlockPortEndpoint(s Service) endpoint.Endpoint {
+	return func(ctx context.Context, request interface{}) (interface{}, error) {
+		req := request.(BlockPortRequest)
+		err := s.BlockPort(req.SrcIP, req.SrcNetwork, req.DstIP, req.DstNetwork, req.Port, req.Protocol)
+		return BlockPortResponse{
+			Error: err,
+		}, nil
+	}
+}

--- a/pkg/firewall/firewall_test.go
+++ b/pkg/firewall/firewall_test.go
@@ -44,4 +44,19 @@ var _ = Describe("Firewall", func() {
 			Ω(err).ShouldNot(HaveOccurred())
 		})
 	})
+
+	Describe("Allow connection", func() {
+		It("Should allow connection", func() {
+			mockIpt, _ := testutils.NewMockIPTService()
+
+			fws, _ := firewall.NewService(mockIpt)
+
+			ip1, _ := abstraction.NewInet("172.18.0.0/16")
+			ip2, _ := abstraction.NewInet("172.18.0.0/16")
+
+			err := fws.AllowConnection(ip1, "br-0815", ip2, "br-0815")
+
+			Ω(err).ShouldNot(HaveOccurred())
+		})
+	})
 })

--- a/pkg/firewall/firewall_test.go
+++ b/pkg/firewall/firewall_test.go
@@ -59,4 +59,21 @@ var _ = Describe("Firewall", func() {
 			Ω(err).ShouldNot(HaveOccurred())
 		})
 	})
+
+	Describe("Block connection", func() {
+		It("Should block a connection", func() {
+			mockIpt, _ := testutils.NewMockIPTService()
+
+			fws, _ := firewall.NewService(mockIpt)
+
+			ip1, _ := abstraction.NewInet("172.18.0.0/16")
+			ip2, _ := abstraction.NewInet("172.18.0.0/16")
+
+			fws.AllowConnection(ip1, "br-0815", ip2, "br-0815")
+
+			err := fws.BlockConnection(ip1, "br-0815", ip2, "br-0815")
+
+			Ω(err).ShouldNot(HaveOccurred())
+		})
+	})
 })

--- a/pkg/firewall/firewall_test.go
+++ b/pkg/firewall/firewall_test.go
@@ -76,4 +76,91 @@ var _ = Describe("Firewall", func() {
 			Ω(err).ShouldNot(HaveOccurred())
 		})
 	})
+
+	Describe("Allow port", func() {
+		It("Should allow a port", func() {
+			mockIpt, _ := testutils.NewMockIPTService()
+
+			fws, _ := firewall.NewService(mockIpt)
+
+			ip1, _ := abstraction.NewInet("172.18.0.0/16")
+			ip2, _ := abstraction.NewInet("172.18.0.0/16")
+
+			err := fws.AllowPort(ip1, "br-0815", ip2, "br-0815", 8080, "tcp")
+
+			Ω(err).ShouldNot(HaveOccurred())
+		})
+
+		It("Should error on invalid protocol", func() {
+			mockIpt, _ := testutils.NewMockIPTService()
+
+			fws, _ := firewall.NewService(mockIpt)
+
+			ip1, _ := abstraction.NewInet("172.18.0.0/16")
+			ip2, _ := abstraction.NewInet("172.18.0.0/16")
+
+			err := fws.AllowPort(ip1, "br-0815", ip2, "br-0815", 8080, "DPD")
+
+			Ω(err).Should(HaveOccurred())
+		})
+
+		It("Should error on existing rule", func() {
+			mockIpt, _ := testutils.NewMockIPTService()
+
+			fws, _ := firewall.NewService(mockIpt)
+
+			ip1, _ := abstraction.NewInet("172.18.0.0/16")
+			ip2, _ := abstraction.NewInet("172.18.0.0/16")
+
+			fws.AllowPort(ip1, "br-0815", ip2, "br-0815", 8080, "udp")
+			err := fws.AllowPort(ip1, "br-0815", ip2, "br-0815", 8080, "udp")
+
+			Ω(err).Should(HaveOccurred())
+		})
+	})
+
+	Describe("Block port", func() {
+		It("Should block a port", func() {
+			mockIpt, _ := testutils.NewMockIPTService()
+
+			fws, _ := firewall.NewService(mockIpt)
+
+			ip1, _ := abstraction.NewInet("172.18.0.0/16")
+			ip2, _ := abstraction.NewInet("172.18.0.0/16")
+
+			fws.AllowPort(ip1, "br-0815", ip2, "br-0815", 8080, "tcp")
+
+			err := fws.BlockPort(ip1, "br-0815", ip2, "br-0815", 8080, "tcp")
+
+			Ω(err).ShouldNot(HaveOccurred())
+		})
+
+		It("Should error on invalid protocol", func() {
+			mockIpt, _ := testutils.NewMockIPTService()
+
+			fws, _ := firewall.NewService(mockIpt)
+
+			ip1, _ := abstraction.NewInet("172.18.0.0/16")
+			ip2, _ := abstraction.NewInet("172.18.0.0/16")
+
+			fws.AllowPort(ip1, "br-0815", ip2, "br-0815", 8080, "tcp")
+
+			err := fws.BlockPort(ip1, "br-0815", ip2, "br-0815", 8080, "DPD")
+
+			Ω(err).Should(HaveOccurred())
+		})
+
+		It("Should error non-existing rule", func() {
+			mockIpt, _ := testutils.NewMockIPTService()
+
+			fws, _ := firewall.NewService(mockIpt)
+
+			ip1, _ := abstraction.NewInet("172.18.0.0/16")
+			ip2, _ := abstraction.NewInet("172.18.0.0/16")
+
+			err := fws.BlockPort(ip1, "br-0815", ip2, "br-0815", 8080, "DPD")
+
+			Ω(err).Should(HaveOccurred())
+		})
+	})
 })

--- a/pkg/firewall/iptables/iptables_test.go
+++ b/pkg/firewall/iptables/iptables_test.go
@@ -242,4 +242,52 @@ var _ = Describe("Iptables", func() {
 			Ω(err).ShouldNot(HaveOccurred())
 		})
 	})
+
+	Describe("Remove a rule", func() {
+		It("Should remove rule", func() {
+			ipts, _ := iptables.NewService("iptables", testutils.NewMockDB())
+
+			ipts.CreateRule(iptables.AllowPortOutRuleType, iptables.AllowPortOutRule{
+				Protocol: "tcp",
+				Port:     uint16(53),
+				Chain:    "-m lalala",
+			})
+
+			err := ipts.RemoveRule(iptables.AllowPortOutRuleType, iptables.AllowPortOutRule{
+				Protocol: "tcp",
+				Port:     uint16(53),
+				Chain:    "-m lalala",
+			})
+
+			Ω(err).ShouldNot(HaveOccurred())
+		})
+
+		It("Should error on non-removable rule", func() {
+			ipts, _ := iptables.NewService("iptables", testutils.NewMockDB())
+
+			ipts.CreateRule(iptables.CreateChainRuleType, iptables.CreateChainRule{
+				Name:  "KROO-TEST",
+				Table: "nat",
+			})
+
+			err := ipts.RemoveRule(iptables.CreateChainRuleType, iptables.CreateChainRule{
+				Name:  "KROO-TEST",
+				Table: "nat",
+			})
+
+			Ω(err).Should(HaveOccurred())
+		})
+
+		It("Should error on non-existing rule", func() {
+			ipts, _ := iptables.NewService("iptables", testutils.NewMockDB())
+
+			err := ipts.RemoveRule(iptables.AllowPortOutRuleType, iptables.AllowPortOutRule{
+				Protocol: "tcp",
+				Port:     uint16(53),
+				Chain:    "-m lalala",
+			})
+
+			Ω(err).Should(HaveOccurred())
+		})
+	})
 })

--- a/pkg/firewall/iptables/iptables_test.go
+++ b/pkg/firewall/iptables/iptables_test.go
@@ -75,6 +75,16 @@ var _ = Describe("Iptables", func() {
 			Ω(err).ShouldNot(HaveOccurred())
 		})
 
+		It("Should create a new chain in default table", func() {
+			ipts, _ := iptables.NewService("iptables", testutils.NewMockDB())
+
+			err := ipts.CreateRule(iptables.CreateChainRuleType, iptables.CreateChainRule{
+				Name: "KROO-TEST",
+			})
+
+			Ω(err).ShouldNot(HaveOccurred())
+		})
+
 		It("Should create a new JumpToChainRule", func() {
 			ipts, _ := iptables.NewService("iptables", testutils.NewMockDB())
 
@@ -241,6 +251,33 @@ var _ = Describe("Iptables", func() {
 
 			Ω(err).ShouldNot(HaveOccurred())
 		})
+
+		It("Should error on invalid rule", func() {
+			ipts, _ := iptables.NewService("iptables", testutils.NewMockDB())
+
+			err := ipts.CreateRule(iptables.AllowPortInRuleType, iptables.CreateChainRule{
+				Name:  "KROO-TEST",
+				Table: "nat",
+			})
+
+			Ω(err).Should(HaveOccurred())
+		})
+
+		It("Should error on existing rule", func() {
+			ipts, _ := iptables.NewService("iptables", testutils.NewMockDB())
+
+			ipts.CreateRule(iptables.CreateChainRuleType, iptables.CreateChainRule{
+				Name:  "KROO-TEST",
+				Table: "nat",
+			})
+
+			err := ipts.CreateRule(iptables.CreateChainRuleType, iptables.CreateChainRule{
+				Name:  "KROO-TEST",
+				Table: "nat",
+			})
+
+			Ω(err).Should(HaveOccurred())
+		})
 	})
 
 	Describe("Remove a rule", func() {
@@ -260,6 +297,24 @@ var _ = Describe("Iptables", func() {
 			})
 
 			Ω(err).ShouldNot(HaveOccurred())
+		})
+
+		It("Should error on invalid rule", func() {
+			ipts, _ := iptables.NewService("iptables", testutils.NewMockDB())
+
+			ipts.CreateRule(iptables.AllowPortOutRuleType, iptables.AllowPortOutRule{
+				Protocol: "tcp",
+				Port:     uint16(53),
+				Chain:    "-m lalala",
+			})
+
+			err := ipts.RemoveRule(iptables.CreateChainRuleType, iptables.AllowPortOutRule{
+				Protocol: "tcp",
+				Port:     uint16(53),
+				Chain:    "-m lalala",
+			})
+
+			Ω(err).Should(HaveOccurred())
 		})
 
 		It("Should error on non-removable rule", func() {

--- a/pkg/firewall/iptables/service.go
+++ b/pkg/firewall/iptables/service.go
@@ -61,7 +61,8 @@ func createHash(cmd string) string {
 	return fmt.Sprintf("%x", sum)
 }
 
-func (s *service) createRuleEntryString(ruleType int, ruleData interface{}) (RuleEntry, string, error) {
+// CreateRuleEntryString creates a rule entry and the command string from a type and data
+func (s *service) CreateRuleEntryString(ruleType int, ruleData interface{}) (RuleEntry, string, error) {
 	errInvalidData := errors.New("Invalid rule data")
 	re := RuleEntry{}
 	cmdStr := ""
@@ -382,7 +383,7 @@ func (s *service) createRuleEntryString(ruleType int, ruleData interface{}) (Rul
 
 func (s *service) CreateRule(ruleType int, ruleData interface{}) error {
 
-	re, cmdStr, err := s.createRuleEntryString(ruleType, ruleData)
+	re, cmdStr, err := s.CreateRuleEntryString(ruleType, ruleData)
 	if err != nil {
 		return err
 	}
@@ -405,7 +406,7 @@ func (s *service) CreateRule(ruleType int, ruleData interface{}) error {
 }
 
 func (s *service) RemoveRule(ruleType int, ruleData interface{}) error {
-	re, cmdStr, err := s.createRuleEntryString(ruleType, ruleData)
+	re, cmdStr, err := s.CreateRuleEntryString(ruleType, ruleData)
 	if err != nil {
 		return err
 	}

--- a/pkg/firewall/iptables/service.go
+++ b/pkg/firewall/iptables/service.go
@@ -384,7 +384,6 @@ func (s *service) CreateRuleEntryString(ruleType int, ruleData interface{}) (Rul
 }
 
 func (s *service) CreateRule(ruleType int, ruleData interface{}) error {
-
 	re, cmdStr, err := s.CreateRuleEntryString(ruleType, ruleData)
 	if err != nil {
 		return err

--- a/pkg/firewall/iptables/service.go
+++ b/pkg/firewall/iptables/service.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"os/exec"
+	"strings"
 
 	"github.com/kontainerooo/kontainer.ooo/pkg/abstraction"
 )
@@ -15,6 +16,9 @@ import (
 type Service interface {
 	// CreateRule creates a rule with a given type and data
 	CreateRule(ruleType int, ruleData interface{}) error
+
+	// RemoveRule removes a rule in case it exists
+	RemoveRule(ruleType int, ruleData interface{}) error
 }
 
 type dbAdapter interface {
@@ -22,6 +26,7 @@ type dbAdapter interface {
 	AutoMigrate(...interface{}) error
 	Create(interface{}) error
 	Where(interface{}, ...interface{}) error
+	Delete(interface{}, ...interface{}) error
 }
 
 type service struct {
@@ -56,7 +61,7 @@ func createHash(cmd string) string {
 	return fmt.Sprintf("%x", sum)
 }
 
-func (s *service) CreateRule(ruleType int, ruleData interface{}) error {
+func (s *service) createRuleEntryString(ruleType int, ruleData interface{}) (RuleEntry, string, error) {
 	errInvalidData := errors.New("Invalid rule data")
 	re := RuleEntry{}
 	cmdStr := ""
@@ -65,7 +70,7 @@ func (s *service) CreateRule(ruleType int, ruleData interface{}) error {
 	case CreateChainRuleType:
 		rd, ok := ruleData.(CreateChainRule)
 		if !ok {
-			return errInvalidData
+			return RuleEntry{}, "", errInvalidData
 		}
 		if rd.Table == "" {
 			rd.Table = "filter"
@@ -80,7 +85,7 @@ func (s *service) CreateRule(ruleType int, ruleData interface{}) error {
 		var buf bytes.Buffer
 		err := CreateChainRuleTmpl.Execute(&buf, rd)
 		if err != nil {
-			return err
+			return RuleEntry{}, "", err
 		}
 
 		cmdStr = buf.String()
@@ -88,7 +93,7 @@ func (s *service) CreateRule(ruleType int, ruleData interface{}) error {
 	case JumpToChainRuleType:
 		rd, ok := ruleData.(JumpToChainRule)
 		if !ok {
-			return errInvalidData
+			return RuleEntry{}, "", errInvalidData
 		}
 		if rd.Table == "" {
 			rd.Table = "filter"
@@ -103,7 +108,7 @@ func (s *service) CreateRule(ruleType int, ruleData interface{}) error {
 		var buf bytes.Buffer
 		err := JumpToChainRuleTmpl.Execute(&buf, rd)
 		if err != nil {
-			return err
+			return RuleEntry{}, "", err
 		}
 
 		cmdStr = buf.String()
@@ -111,7 +116,7 @@ func (s *service) CreateRule(ruleType int, ruleData interface{}) error {
 	case IsolationRuleType:
 		rd, ok := ruleData.(IsolationRule)
 		if !ok {
-			return errInvalidData
+			return RuleEntry{}, "", errInvalidData
 		}
 		rule := Rule{
 			Data:     rd,
@@ -123,7 +128,7 @@ func (s *service) CreateRule(ruleType int, ruleData interface{}) error {
 		var buf bytes.Buffer
 		err := IsolationRuleTmpl.Execute(&buf, rd)
 		if err != nil {
-			return err
+			return RuleEntry{}, "", err
 		}
 
 		cmdStr = buf.String()
@@ -131,7 +136,7 @@ func (s *service) CreateRule(ruleType int, ruleData interface{}) error {
 	case OutgoingOutRuleType:
 		rd, ok := ruleData.(OutgoingOutRule)
 		if !ok {
-			return errInvalidData
+			return RuleEntry{}, "", errInvalidData
 		}
 		rule := Rule{
 			Data:     rd,
@@ -143,7 +148,7 @@ func (s *service) CreateRule(ruleType int, ruleData interface{}) error {
 		var buf bytes.Buffer
 		err := OutgoingOutRuleTmpl.Execute(&buf, rd)
 		if err != nil {
-			return err
+			return RuleEntry{}, "", err
 		}
 
 		cmdStr = buf.String()
@@ -151,7 +156,7 @@ func (s *service) CreateRule(ruleType int, ruleData interface{}) error {
 	case OutgoingInRuleType:
 		rd, ok := ruleData.(OutgoingInRule)
 		if !ok {
-			return errInvalidData
+			return RuleEntry{}, "", errInvalidData
 		}
 		rule := Rule{
 			Data:     rd,
@@ -163,7 +168,7 @@ func (s *service) CreateRule(ruleType int, ruleData interface{}) error {
 		var buf bytes.Buffer
 		err := OutgoingInRuleTmpl.Execute(&buf, rd)
 		if err != nil {
-			return err
+			return RuleEntry{}, "", err
 		}
 
 		cmdStr = buf.String()
@@ -171,7 +176,7 @@ func (s *service) CreateRule(ruleType int, ruleData interface{}) error {
 	case LinkContainerPortToRuleType:
 		rd, ok := ruleData.(LinkContainerPortToRule)
 		if !ok {
-			return errInvalidData
+			return RuleEntry{}, "", errInvalidData
 		}
 		rule := Rule{
 			Data:     rd,
@@ -183,7 +188,7 @@ func (s *service) CreateRule(ruleType int, ruleData interface{}) error {
 		var buf bytes.Buffer
 		err := LinkContainerPortToRuleTmpl.Execute(&buf, rd)
 		if err != nil {
-			return err
+			return RuleEntry{}, "", err
 		}
 
 		cmdStr = buf.String()
@@ -191,7 +196,7 @@ func (s *service) CreateRule(ruleType int, ruleData interface{}) error {
 	case LinkContainerPortFromRuleType:
 		rd, ok := ruleData.(LinkContainerPortFromRule)
 		if !ok {
-			return errInvalidData
+			return RuleEntry{}, "", errInvalidData
 		}
 		rule := Rule{
 			Data:     rd,
@@ -203,7 +208,7 @@ func (s *service) CreateRule(ruleType int, ruleData interface{}) error {
 		var buf bytes.Buffer
 		err := LinkContainerPortFromRuleTmpl.Execute(&buf, rd)
 		if err != nil {
-			return err
+			return RuleEntry{}, "", err
 		}
 
 		cmdStr = buf.String()
@@ -211,7 +216,7 @@ func (s *service) CreateRule(ruleType int, ruleData interface{}) error {
 	case LinkContainerToRuleType:
 		rd, ok := ruleData.(LinkContainerToRule)
 		if !ok {
-			return errInvalidData
+			return RuleEntry{}, "", errInvalidData
 		}
 		rule := Rule{
 			Data:     rd,
@@ -223,7 +228,7 @@ func (s *service) CreateRule(ruleType int, ruleData interface{}) error {
 		var buf bytes.Buffer
 		err := LinkContainerToRuleTmpl.Execute(&buf, rd)
 		if err != nil {
-			return err
+			return RuleEntry{}, "", err
 		}
 
 		cmdStr = buf.String()
@@ -231,7 +236,7 @@ func (s *service) CreateRule(ruleType int, ruleData interface{}) error {
 	case LinkContainerFromRuleType:
 		rd, ok := ruleData.(LinkContainerFromRule)
 		if !ok {
-			return errInvalidData
+			return RuleEntry{}, "", errInvalidData
 		}
 		rule := Rule{
 			Data:     rd,
@@ -243,7 +248,7 @@ func (s *service) CreateRule(ruleType int, ruleData interface{}) error {
 		var buf bytes.Buffer
 		err := LinkContainerFromRuleTmpl.Execute(&buf, rd)
 		if err != nil {
-			return err
+			return RuleEntry{}, "", err
 		}
 
 		cmdStr = buf.String()
@@ -251,7 +256,7 @@ func (s *service) CreateRule(ruleType int, ruleData interface{}) error {
 	case ConnectContainerFromRuleType:
 		rd, ok := ruleData.(ConnectContainerFromRule)
 		if !ok {
-			return errInvalidData
+			return RuleEntry{}, "", errInvalidData
 		}
 		rule := Rule{
 			Data:     rd,
@@ -263,7 +268,7 @@ func (s *service) CreateRule(ruleType int, ruleData interface{}) error {
 		var buf bytes.Buffer
 		err := ConnectContainerFromRuleTmpl.Execute(&buf, rd)
 		if err != nil {
-			return err
+			return RuleEntry{}, "", err
 		}
 
 		cmdStr = buf.String()
@@ -271,7 +276,7 @@ func (s *service) CreateRule(ruleType int, ruleData interface{}) error {
 	case ConnectContainerToRuleType:
 		rd, ok := ruleData.(ConnectContainerToRule)
 		if !ok {
-			return errInvalidData
+			return RuleEntry{}, "", errInvalidData
 		}
 		rule := Rule{
 			Data:     rd,
@@ -283,7 +288,7 @@ func (s *service) CreateRule(ruleType int, ruleData interface{}) error {
 		var buf bytes.Buffer
 		err := ConnectContainerToRuleTmpl.Execute(&buf, rd)
 		if err != nil {
-			return err
+			return RuleEntry{}, "", err
 		}
 
 		cmdStr = buf.String()
@@ -291,7 +296,7 @@ func (s *service) CreateRule(ruleType int, ruleData interface{}) error {
 	case AllowPortInRuleType:
 		rd, ok := ruleData.(AllowPortInRule)
 		if !ok {
-			return errInvalidData
+			return RuleEntry{}, "", errInvalidData
 		}
 		rule := Rule{
 			Data:     rd,
@@ -303,7 +308,7 @@ func (s *service) CreateRule(ruleType int, ruleData interface{}) error {
 		var buf bytes.Buffer
 		err := AllowPortInRuleTmpl.Execute(&buf, rd)
 		if err != nil {
-			return err
+			return RuleEntry{}, "", err
 		}
 
 		cmdStr = buf.String()
@@ -311,7 +316,7 @@ func (s *service) CreateRule(ruleType int, ruleData interface{}) error {
 	case AllowPortOutRuleType:
 		rd, ok := ruleData.(AllowPortOutRule)
 		if !ok {
-			return errInvalidData
+			return RuleEntry{}, "", errInvalidData
 		}
 		rule := Rule{
 			Data:     rd,
@@ -323,7 +328,7 @@ func (s *service) CreateRule(ruleType int, ruleData interface{}) error {
 		var buf bytes.Buffer
 		err := AllowPortOutRuleTmpl.Execute(&buf, rd)
 		if err != nil {
-			return err
+			return RuleEntry{}, "", err
 		}
 
 		cmdStr = buf.String()
@@ -331,7 +336,7 @@ func (s *service) CreateRule(ruleType int, ruleData interface{}) error {
 	case NatOutRuleType:
 		rd, ok := ruleData.(NatOutRule)
 		if !ok {
-			return errInvalidData
+			return RuleEntry{}, "", errInvalidData
 		}
 		rule := Rule{
 			Data:     rd,
@@ -343,7 +348,7 @@ func (s *service) CreateRule(ruleType int, ruleData interface{}) error {
 		var buf bytes.Buffer
 		err := NatOutRuleTmpl.Execute(&buf, rd)
 		if err != nil {
-			return err
+			return RuleEntry{}, "", err
 		}
 
 		cmdStr = buf.String()
@@ -351,7 +356,7 @@ func (s *service) CreateRule(ruleType int, ruleData interface{}) error {
 	case NatMaskRuleType:
 		rd, ok := ruleData.(NatMaskRule)
 		if !ok {
-			return errInvalidData
+			return RuleEntry{}, "", errInvalidData
 		}
 		rule := Rule{
 			Data:     rd,
@@ -363,25 +368,64 @@ func (s *service) CreateRule(ruleType int, ruleData interface{}) error {
 		var buf bytes.Buffer
 		err := NatMaskRuleTmpl.Execute(&buf, rd)
 		if err != nil {
-			return err
+			return RuleEntry{}, "", err
 		}
 
 		cmdStr = buf.String()
 		re.ID = createHash(cmdStr)
 	default:
-		return errors.New("pq: cannot convert input src to FrontendArray")
+		return RuleEntry{}, "", errors.New("pq: cannot convert input src to FrontendArray")
+	}
+
+	return re, cmdStr, nil
+}
+
+func (s *service) CreateRule(ruleType int, ruleData interface{}) error {
+
+	re, cmdStr, err := s.createRuleEntryString(ruleType, ruleData)
+	if err != nil {
+		return err
 	}
 
 	if s.ruleExists(re.ID) {
 		return errors.New("Rule already exists")
 	}
 
-	err := s.executeIPTableCommand(cmdStr)
+	err = s.executeIPTableCommand(cmdStr)
 	if err != nil {
 		return err
 	}
 
 	err = s.db.Create(&re)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (s *service) RemoveRule(ruleType int, ruleData interface{}) error {
+	re, cmdStr, err := s.createRuleEntryString(ruleType, ruleData)
+	if err != nil {
+		return err
+	}
+
+	if !s.ruleExists(re.ID) {
+		return errors.New("Rule does not exist")
+	}
+
+	if !strings.Contains(cmdStr, "-A") {
+		return errors.New("Rule cannot be removed (no -A present)")
+	}
+
+	strings.Replace(cmdStr, "-A", "-D", -1)
+
+	err = s.executeIPTableCommand(cmdStr)
+	if err != nil {
+		return err
+	}
+
+	err = s.db.Delete(&re)
 	if err != nil {
 		return err
 	}

--- a/pkg/firewall/iptables/service.go
+++ b/pkg/firewall/iptables/service.go
@@ -19,6 +19,9 @@ type Service interface {
 
 	// RemoveRule removes a rule in case it exists
 	RemoveRule(ruleType int, ruleData interface{}) error
+
+	// CreateRuleEntryString creates a rule entry and the command string from a type and data
+	CreateRuleEntryString(ruleType int, ruleData interface{}) (RuleEntry, string, error)
 }
 
 type dbAdapter interface {
@@ -61,7 +64,6 @@ func createHash(cmd string) string {
 	return fmt.Sprintf("%x", sum)
 }
 
-// CreateRuleEntryString creates a rule entry and the command string from a type and data
 func (s *service) CreateRuleEntryString(ruleType int, ruleData interface{}) (RuleEntry, string, error) {
 	errInvalidData := errors.New("Invalid rule data")
 	re := RuleEntry{}

--- a/pkg/firewall/service.go
+++ b/pkg/firewall/service.go
@@ -25,12 +25,6 @@ type Service interface {
 
 	// AllowPort sets up a rule to block src from talking to dst on port port
 	BlockPort(srcIP abstraction.Inet, srcNw string, dstIP abstraction.Inet, dstNw string, port uint16, protocol string) error
-
-	// RedirectPort redirects the src port to the dst port on ip
-	RedirectPort(ip abstraction.Inet, src uint32, dst uint32) error
-
-	// RemoveRedirectPort removes a port redirection
-	RemoveRedirectPort(ip abstraction.Inet, src uint32, dst uint32) error
 }
 
 type service struct {
@@ -204,16 +198,6 @@ func (s *service) BlockPort(srcIP abstraction.Inet, srcNw string, dstIP abstract
 		return err
 	}
 
-	return nil
-}
-
-func (s *service) RedirectPort(ip abstraction.Inet, src uint32, dst uint32) error {
-	// TODO: implement
-	return nil
-}
-
-func (s *service) RemoveRedirectPort(ip abstraction.Inet, src uint32, dst uint32) error {
-	// TODO: implement
 	return nil
 }
 

--- a/pkg/firewall/service.go
+++ b/pkg/firewall/service.go
@@ -3,6 +3,7 @@ package firewall
 
 import (
 	"errors"
+	"regexp"
 
 	"github.com/kontainerooo/kontainer.ooo/pkg/abstraction"
 	"github.com/kontainerooo/kontainer.ooo/pkg/firewall/iptables"
@@ -20,10 +21,10 @@ type Service interface {
 	BlockConnection(srcIP abstraction.Inet, srcNw string, dstIP abstraction.Inet, dstNw string) error
 
 	// AllowPort sets up a rule to let src talk to dst on port port
-	AllowPort(src abstraction.Inet, dst abstraction.Inet, port uint32) error
+	AllowPort(srcIP abstraction.Inet, srcNw string, dstIP abstraction.Inet, dstNw string, port uint16, protocol string) error
 
 	// AllowPort sets up a rule to block src from talking to dst on port port
-	BlockPort(src abstraction.Inet, dst abstraction.Inet, port uint32) error
+	BlockPort(srcIP abstraction.Inet, srcNw string, dstIP abstraction.Inet, dstNw string, port uint16, protocol string) error
 
 	// RedirectPort redirects the src port to the dst port on ip
 	RedirectPort(ip abstraction.Inet, src uint32, dst uint32) error
@@ -135,13 +136,74 @@ func (s *service) BlockConnection(srcIP abstraction.Inet, srcNw string, dstIP ab
 	return nil
 }
 
-func (s *service) AllowPort(src abstraction.Inet, dst abstraction.Inet, port uint32) error {
-	// TODO: implement
+func (s *service) isValidProtocol(p string) bool {
+	// TODO: which protocols do we support?
+	r := regexp.MustCompile("tcp|udp")
+	if r.MatchString(p) {
+		return true
+	}
+	return false
+}
+
+func (s *service) AllowPort(srcIP abstraction.Inet, srcNw string, dstIP abstraction.Inet, dstNw string, port uint16, protocol string) error {
+	if !s.isValidProtocol(protocol) {
+		return errors.New("Not a valid protocol")
+	}
+
+	err := s.iptClient.CreateRule(iptables.LinkContainerPortFromRuleType, iptables.LinkContainerPortFromRule{
+		SrcIP:      srcIP,
+		SrcNetwork: srcNw,
+		DstIP:      dstIP,
+		DstNetwork: dstNw,
+		Protocol:   protocol,
+	})
+	if err != nil {
+		return err
+	}
+
+	err = s.iptClient.CreateRule(iptables.LinkContainerPortToRuleType, iptables.LinkContainerPortToRule{
+		SrcIP:      srcIP,
+		SrcNetwork: srcNw,
+		DstIP:      dstIP,
+		DstNetwork: dstNw,
+		Protocol:   protocol,
+		DstPort:    port,
+	})
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 
-func (s *service) BlockPort(src abstraction.Inet, dst abstraction.Inet, port uint32) error {
-	// TODO: implement
+func (s *service) BlockPort(srcIP abstraction.Inet, srcNw string, dstIP abstraction.Inet, dstNw string, port uint16, protocol string) error {
+	if !s.isValidProtocol(protocol) {
+		return errors.New("Not a valid protocol")
+	}
+
+	err := s.iptClient.RemoveRule(iptables.LinkContainerPortFromRuleType, iptables.LinkContainerPortFromRule{
+		SrcIP:      srcIP,
+		SrcNetwork: srcNw,
+		DstIP:      dstIP,
+		DstNetwork: dstNw,
+		Protocol:   protocol,
+	})
+	if err != nil {
+		return err
+	}
+
+	err = s.iptClient.RemoveRule(iptables.LinkContainerPortToRuleType, iptables.LinkContainerPortToRule{
+		SrcIP:      srcIP,
+		SrcNetwork: srcNw,
+		DstIP:      dstIP,
+		DstNetwork: dstNw,
+		Protocol:   protocol,
+		DstPort:    port,
+	})
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/pkg/firewall/service.go
+++ b/pkg/firewall/service.go
@@ -14,7 +14,7 @@ type Service interface {
 	InitBridge(ip abstraction.Inet, netIf string) error
 
 	// AllowConnection sets up a rule to let src talk to dst
-	AllowConnection(src abstraction.Inet, dst abstraction.Inet) error
+	AllowConnection(srcIP abstraction.Inet, srcNw string, dstIP abstraction.Inet, dstNw string) error
 
 	// AllowConnection sets up a rule to block src from talking to dst
 	BlockConnection(src abstraction.Inet, dst abstraction.Inet) error
@@ -87,8 +87,27 @@ func (s *service) InitBridge(ip abstraction.Inet, netIf string) error {
 	return nil
 }
 
-func (s *service) AllowConnection(src abstraction.Inet, dst abstraction.Inet) error {
-	// TODO: implement
+func (s *service) AllowConnection(srcIP abstraction.Inet, srcNw string, dstIP abstraction.Inet, dstNw string) error {
+	err := s.iptClient.CreateRule(iptables.LinkContainerFromRuleType, iptables.LinkContainerFromRule{
+		SrcIP:      srcIP,
+		SrcNetwork: srcNw,
+		DstIP:      dstIP,
+		DstNetwork: dstNw,
+	})
+	if err != nil {
+		return err
+	}
+
+	err = s.iptClient.CreateRule(iptables.LinkContainerToRuleType, iptables.LinkContainerToRule{
+		SrcIP:      srcIP,
+		SrcNetwork: srcNw,
+		DstIP:      dstIP,
+		DstNetwork: dstNw,
+	})
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/pkg/firewall/service.go
+++ b/pkg/firewall/service.go
@@ -17,7 +17,7 @@ type Service interface {
 	AllowConnection(srcIP abstraction.Inet, srcNw string, dstIP abstraction.Inet, dstNw string) error
 
 	// AllowConnection sets up a rule to block src from talking to dst
-	BlockConnection(src abstraction.Inet, dst abstraction.Inet) error
+	BlockConnection(srcIP abstraction.Inet, srcNw string, dstIP abstraction.Inet, dstNw string) error
 
 	// AllowPort sets up a rule to let src talk to dst on port port
 	AllowPort(src abstraction.Inet, dst abstraction.Inet, port uint32) error
@@ -111,8 +111,27 @@ func (s *service) AllowConnection(srcIP abstraction.Inet, srcNw string, dstIP ab
 	return nil
 }
 
-func (s *service) BlockConnection(src abstraction.Inet, dst abstraction.Inet) error {
-	// TODO: implement
+func (s *service) BlockConnection(srcIP abstraction.Inet, srcNw string, dstIP abstraction.Inet, dstNw string) error {
+	err := s.iptClient.RemoveRule(iptables.LinkContainerFromRuleType, iptables.LinkContainerFromRule{
+		SrcIP:      srcIP,
+		SrcNetwork: srcNw,
+		DstIP:      dstIP,
+		DstNetwork: dstNw,
+	})
+	if err != nil {
+		return err
+	}
+
+	err = s.iptClient.RemoveRule(iptables.LinkContainerToRuleType, iptables.LinkContainerToRule{
+		SrcIP:      srcIP,
+		SrcNetwork: srcNw,
+		DstIP:      dstIP,
+		DstNetwork: dstNw,
+	})
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/pkg/firewall/transport_grpc.go
+++ b/pkg/firewall/transport_grpc.go
@@ -1,0 +1,252 @@
+package firewall
+
+import (
+	"context"
+
+	"github.com/go-kit/kit/log"
+	grpctransport "github.com/go-kit/kit/transport/grpc"
+	"github.com/kontainerooo/kontainer.ooo/pkg/abstraction"
+	"github.com/kontainerooo/kontainer.ooo/pkg/pb"
+	oldcontext "golang.org/x/net/context"
+)
+
+// MakeGRPCServer makes a set of Endpoints available as a gRPC firewallServer
+func MakeGRPCServer(ctx context.Context, endpoints Endpoints, logger log.Logger) pb.FirewallServiceServer {
+	options := []grpctransport.ServerOption{
+		grpctransport.ServerErrorLogger(logger),
+	}
+
+	return &grpcServer{
+		initbridge: grpctransport.NewServer(
+			endpoints.InitBridgeEndpoint,
+			DecodeGRPCInitBridgeRequest,
+			EncodeGRPCInitBridgeResponse,
+			options...,
+		),
+		allowconnection: grpctransport.NewServer(
+			endpoints.AllowConnectionEndpoint,
+			DecodeGRPCAllowConnectionRequest,
+			EncodeGRPCAllowConnectionResponse,
+			options...,
+		),
+		blockconnection: grpctransport.NewServer(
+			endpoints.BlockConnectionEndpoint,
+			DecodeGRPCBlockConnectionRequest,
+			EncodeGRPCBlockConnectionResponse,
+			options...,
+		),
+		allowport: grpctransport.NewServer(
+			endpoints.AllowPortEndpoint,
+			DecodeGRPCAllowPortRequest,
+			EncodeGRPCAllowPortResponse,
+			options...,
+		),
+		blockport: grpctransport.NewServer(
+			endpoints.BlockPortEndpoint,
+			DecodeGRPCBlockPortRequest,
+			EncodeGRPCBlockPortResponse,
+			options...,
+		),
+	}
+}
+
+type grpcServer struct {
+	initbridge      grpctransport.Handler
+	allowconnection grpctransport.Handler
+	blockconnection grpctransport.Handler
+	allowport       grpctransport.Handler
+	blockport       grpctransport.Handler
+}
+
+func (s *grpcServer) InitBridge(ctx oldcontext.Context, req *pb.InitBridgeRequest) (*pb.InitBridgeResponse, error) {
+	_, res, err := s.initbridge.ServeGRPC(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	return res.(*pb.InitBridgeResponse), nil
+}
+
+func (s *grpcServer) AllowConnection(ctx oldcontext.Context, req *pb.AllowConnectionRequest) (*pb.AllowConnectionResponse, error) {
+	_, res, err := s.allowconnection.ServeGRPC(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	return res.(*pb.AllowConnectionResponse), nil
+}
+
+func (s *grpcServer) BlockConnection(ctx oldcontext.Context, req *pb.BlockConnectionRequest) (*pb.BlockConnectionResponse, error) {
+	_, res, err := s.blockconnection.ServeGRPC(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	return res.(*pb.BlockConnectionResponse), nil
+}
+
+func (s *grpcServer) AllowPort(ctx oldcontext.Context, req *pb.AllowPortRequest) (*pb.AllowPortResponse, error) {
+	_, res, err := s.allowport.ServeGRPC(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	return res.(*pb.AllowPortResponse), nil
+}
+
+func (s *grpcServer) BlockPort(ctx oldcontext.Context, req *pb.BlockPortRequest) (*pb.BlockPortResponse, error) {
+	_, res, err := s.blockport.ServeGRPC(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	return res.(*pb.BlockPortResponse), nil
+}
+
+// DecodeGRPCInitBridgeRequest is a transport/grpc.DecodeRequestFunc that converts a
+// gRPC InitBridge request to a messages/firewall.proto-domain initbridge request.
+func DecodeGRPCInitBridgeRequest(_ context.Context, grpcReq interface{}) (interface{}, error) {
+	req := grpcReq.(*pb.InitBridgeRequest)
+	ip, err := abstraction.NewInet(req.IP)
+	if err != nil {
+		return InitBridgeRequest{}, err
+	}
+	return InitBridgeRequest{
+		IP:    ip,
+		NetIf: req.NetworkName,
+	}, nil
+}
+
+// DecodeGRPCAllowConnectionRequest is a transport/grpc.DecodeRequestFunc that converts a
+// gRPC AllowConnection request to a messages/firewall.proto-domain allowconnection request.
+func DecodeGRPCAllowConnectionRequest(_ context.Context, grpcReq interface{}) (interface{}, error) {
+	req := grpcReq.(*pb.AllowConnectionRequest)
+	srcIP, err := abstraction.NewInet(req.SrcIP)
+	if err != nil {
+		return AllowConnectionRequest{}, err
+	}
+	dstIP, err := abstraction.NewInet(req.DstIP)
+	if err != nil {
+		return AllowConnectionRequest{}, err
+	}
+	return AllowConnectionRequest{
+		SrcIP:      srcIP,
+		DstIP:      dstIP,
+		SrcNetwork: req.SrcNetwork,
+		DstNetwork: req.DstNetwork,
+	}, nil
+}
+
+// DecodeGRPCBlockConnectionRequest is a transport/grpc.DecodeRequestFunc that converts a
+// gRPC BlockConnection request to a messages/firewall.proto-domain blockconnection request.
+func DecodeGRPCBlockConnectionRequest(_ context.Context, grpcReq interface{}) (interface{}, error) {
+	req := grpcReq.(*pb.BlockConnectionRequest)
+	srcIP, err := abstraction.NewInet(req.SrcIP)
+	if err != nil {
+		return BlockConnectionRequest{}, err
+	}
+	dstIP, err := abstraction.NewInet(req.DstIP)
+	if err != nil {
+		return BlockConnectionRequest{}, err
+	}
+	return BlockConnectionRequest{
+		SrcIP:      srcIP,
+		DstIP:      dstIP,
+		SrcNetwork: req.SrcNetwork,
+		DstNetwork: req.DstNetwork,
+	}, nil
+}
+
+// DecodeGRPCAllowPortRequest is a transport/grpc.DecodeRequestFunc that converts a
+// gRPC AllowPort request to a messages/firewall.proto-domain allowport request.
+func DecodeGRPCAllowPortRequest(_ context.Context, grpcReq interface{}) (interface{}, error) {
+	req := grpcReq.(*pb.AllowPortRequest)
+	srcIP, err := abstraction.NewInet(req.SrcIP)
+	if err != nil {
+		return AllowPortRequest{}, err
+	}
+	dstIP, err := abstraction.NewInet(req.DstIP)
+	if err != nil {
+		return AllowPortRequest{}, err
+	}
+	return AllowPortRequest{
+		SrcIP:      srcIP,
+		DstIP:      dstIP,
+		SrcNetwork: req.SrcNetwork,
+		DstNetwork: req.DstNetwork,
+		Protocol:   req.Protocol,
+		Port:       uint16(req.Port),
+	}, nil
+}
+
+// DecodeGRPCBlockPortRequest is a transport/grpc.DecodeRequestFunc that converts a
+// gRPC BlockPort request to a messages/firewall.proto-domain blockport request.
+func DecodeGRPCBlockPortRequest(_ context.Context, grpcReq interface{}) (interface{}, error) {
+	req := grpcReq.(*pb.BlockPortRequest)
+	srcIP, err := abstraction.NewInet(req.SrcIP)
+	if err != nil {
+		return BlockPortRequest{}, err
+	}
+	dstIP, err := abstraction.NewInet(req.DstIP)
+	if err != nil {
+		return BlockPortRequest{}, err
+	}
+	return BlockPortRequest{
+		SrcIP:      srcIP,
+		DstIP:      dstIP,
+		SrcNetwork: req.SrcNetwork,
+		DstNetwork: req.DstNetwork,
+		Protocol:   req.Protocol,
+		Port:       uint16(req.Port),
+	}, nil
+}
+
+// EncodeGRPCInitBridgeResponse is a transport/grpc.EncodeRequestFunc that converts a
+// messages/firewall.proto-domain initbridge response to a gRPC InitBridge response.
+func EncodeGRPCInitBridgeResponse(_ context.Context, response interface{}) (interface{}, error) {
+	res := response.(InitBridgeResponse)
+	gRPCRes := &pb.InitBridgeResponse{}
+	if res.Error != nil {
+		gRPCRes.Error = res.Error.Error()
+	}
+	return gRPCRes, nil
+}
+
+// EncodeGRPCAllowConnectionResponse is a transport/grpc.EncodeRequestFunc that converts a
+// messages/firewall.proto-domain allowconnection response to a gRPC AllowConnection response.
+func EncodeGRPCAllowConnectionResponse(_ context.Context, response interface{}) (interface{}, error) {
+	res := response.(AllowConnectionResponse)
+	gRPCRes := &pb.AllowConnectionResponse{}
+	if res.Error != nil {
+		gRPCRes.Error = res.Error.Error()
+	}
+	return gRPCRes, nil
+}
+
+// EncodeGRPCBlockConnectionResponse is a transport/grpc.EncodeRequestFunc that converts a
+// messages/firewall.proto-domain blockconnection response to a gRPC BlockConnection response.
+func EncodeGRPCBlockConnectionResponse(_ context.Context, response interface{}) (interface{}, error) {
+	res := response.(BlockConnectionResponse)
+	gRPCRes := &pb.BlockConnectionResponse{}
+	if res.Error != nil {
+		gRPCRes.Error = res.Error.Error()
+	}
+	return gRPCRes, nil
+}
+
+// EncodeGRPCAllowPortResponse is a transport/grpc.EncodeRequestFunc that converts a
+// messages/firewall.proto-domain allowport response to a gRPC AllowPort response.
+func EncodeGRPCAllowPortResponse(_ context.Context, response interface{}) (interface{}, error) {
+	res := response.(AllowPortResponse)
+	gRPCRes := &pb.AllowPortResponse{}
+	if res.Error != nil {
+		gRPCRes.Error = res.Error.Error()
+	}
+	return gRPCRes, nil
+}
+
+// EncodeGRPCBlockPortResponse is a transport/grpc.EncodeRequestFunc that converts a
+// messages/firewall.proto-domain blockport response to a gRPC BlockPort response.
+func EncodeGRPCBlockPortResponse(_ context.Context, response interface{}) (interface{}, error) {
+	res := response.(BlockPortResponse)
+	gRPCRes := &pb.BlockPortResponse{}
+	if res.Error != nil {
+		gRPCRes.Error = res.Error.Error()
+	}
+	return gRPCRes, nil
+}


### PR DESCRIPTION
This PR implements firewall and iptables service functionality to connect and link container networks.

Changes in `messages/`:
- Create firewall service messages

Changes in `pkg/firewall`:
- Create firewall service client
- Create firewall service endpoints
- Create firewall service grpc transport
- Create AllowConnection, BlockConnection, AllowPort and BlockPort functions
- Create tests

Changes in `pkg/firewall/iptables`:
- Change function layout

Changes in `testutils/`:
- Create actual mockIPT service