### PR TITLE
Create iptables restore function

### DIFF
--- a/pkg/firewall/iptables/service.go
+++ b/pkg/firewall/iptables/service.go
@@ -468,7 +468,7 @@ func (s *service) RestoreRules() error {
 		return err
 	}
 
-	cmd := ExecCommand("iptables-restore", "-c")
+	cmd := ExecCommand(s.iptRestorePath, "-c")
 
 	cmd.Stdin = strings.NewReader(str)
 

--- a/pkg/firewall/iptables/service.go
+++ b/pkg/firewall/iptables/service.go
@@ -22,6 +22,9 @@ type Service interface {
 
 	// CreateRuleEntryString creates a rule entry and the command string from a type and data
 	CreateRuleEntryString(ruleType int, ruleData interface{}) (RuleEntry, string, error)
+
+	// RestoreRules restores all rules from the database using iptables-restore
+	RestoreRules() error
 }
 
 type dbAdapter interface {
@@ -29,12 +32,14 @@ type dbAdapter interface {
 	AutoMigrate(...interface{}) error
 	Create(interface{}) error
 	Where(interface{}, ...interface{}) error
+	Find(interface{}, ...interface{}) error
 	Delete(interface{}, ...interface{}) error
 }
 
 type service struct {
-	iptPath string
-	db      dbAdapter
+	iptPath        string
+	iptRestorePath string
+	db             dbAdapter
 }
 
 func (s *service) executeIPTableCommand(c string) error {
@@ -435,18 +440,65 @@ func (s *service) RemoveRule(ruleType int, ruleData interface{}) error {
 	return nil
 }
 
+func (s *service) createExportStrings() (string, error) {
+	restoreStr := ""
+
+	res := []RuleEntry{}
+
+	err := s.db.Find(&res)
+	if err != nil {
+		return "", err
+	}
+
+	for _, v := range res {
+		_, cmdStr, err := s.CreateRuleEntryString(v.rule.RuleType, v.rule.Data)
+		if err != nil {
+			return "", err
+		}
+
+		restoreStr = fmt.Sprintf("%s%s\n", restoreStr, cmdStr)
+	}
+
+	return restoreStr, nil
+}
+
+func (s *service) RestoreRules() error {
+	str, err := s.createExportStrings()
+	if err != nil {
+		return err
+	}
+
+	cmd := ExecCommand("iptables-restore", "-c")
+
+	cmd.Stdin = strings.NewReader(str)
+
+	err = cmd.Run()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // ExecCommand is a wrapper around exec.Command used for testing
 var ExecCommand = exec.Command
 
 // NewService creates a new iptables service
-func NewService(iptPath string, db dbAdapter) (Service, error) {
+func NewService(iptPath string, iptRestorePath string, db dbAdapter) (Service, error) {
 	s := &service{
-		iptPath: iptPath,
-		db:      db,
+		iptPath:        iptPath,
+		iptRestorePath: iptRestorePath,
+		db:             db,
 	}
 
 	cmd := ExecCommand(iptPath, "--version")
 	err := cmd.Run()
+	if err != nil {
+		return nil, err
+	}
+
+	cmd = ExecCommand(iptRestorePath, "--help")
+	err = cmd.Run()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/testutils/mockIPT.go
+++ b/pkg/testutils/mockIPT.go
@@ -73,7 +73,7 @@ func (m *MockIPTService) ListRules() []string {
 func NewMockIPTService() (*MockIPTService, error) {
 	db := NewMockDB()
 	iptables.ExecCommand = fakeExecCommand
-	ipts, err := iptables.NewService("iptables", db)
+	ipts, err := iptables.NewService("iptables", "iptables-restore", db)
 
 	return &MockIPTService{
 		rules: make(map[string]iptables.RuleEntry),

--- a/pkg/testutils/mockIPT.go
+++ b/pkg/testutils/mockIPT.go
@@ -69,6 +69,11 @@ func (m *MockIPTService) ListRules() []string {
 	return []string{}
 }
 
+// RestoreRules is not mocked
+func (m *MockIPTService) RestoreRules() error {
+	return nil
+}
+
 // NewMockIPTService creates a new MockIPTServicet
 func NewMockIPTService() (*MockIPTService, error) {
 	db := NewMockDB()


### PR DESCRIPTION
This PR implements the iptables-restore functionality to restore an iptables configuration from the database.

This resolves #143 