### PR TITLE
Network Service

### DIFF
--- a/messages/network.proto
+++ b/messages/network.proto
@@ -1,0 +1,90 @@
+syntax = "proto3";
+package network;
+option go_package = "pb";
+
+service NetworkService {
+  rpc CreatePrimaryNetworkForContainer (CreatePrimaryNetworkForContainerRequest) returns (CreatePrimaryNetworkForContainerResponse);
+  rpc CreateNetwork (CreateNetworkRequest) returns (CreateNetworkResponse);
+  rpc RemoveNetworkByName (RemoveNetworkByNameRequest) returns (RemoveNetworkByNameResponse);
+  rpc AddContainerToNetwork (AddContainerToNetworkRequest) returns (AddContainerToNetworkResponse);
+  rpc RemoveContainerFromNetwork (RemoveContainerFromNetworkRequest) returns (RemoveContainerFromNetworkResponse);
+  rpc ExposePortToContainer (ExposePortToContainerRequest) returns (ExposePortToContainerResponse);
+  rpc RemovePortFromContainer (RemovePortFromContainerRequest) returns (RemovePortFromContainerResponse);
+}
+
+message NetworkConfig {
+    string Name = 1;
+    string Driver = 2;
+}
+
+message CreatePrimaryNetworkForContainerRequest {
+    uint32 Refid = 1;
+    NetworkConfig Config = 2;
+    string ContainerID = 3;
+}
+
+message CreatePrimaryNetworkForContainerResponse {
+    string error = 1;
+}
+
+message CreateNetworkRequest {
+    uint32 Refid = 1;
+    NetworkConfig Config = 2;
+}
+
+message CreateNetworkResponse {
+    string error = 1;
+}
+
+message RemoveNetworkByNameRequest {
+    uint32 Refid = 1;
+    string Name = 2;
+}
+
+message RemoveNetworkByNameResponse {
+    string error = 1;
+}
+
+message AddContainerToNetworkRequest {
+    uint32 Refid = 1;
+    string Name = 2;
+    string ContainerID = 3;
+}
+
+message AddContainerToNetworkResponse {
+    string error = 2;
+}
+
+message RemoveContainerFromNetworkRequest {
+    uint32 Refid = 1;
+    string Name = 2;
+    string ContainerID = 3;
+}
+
+message RemoveContainerFromNetworkResponse {
+    string error = 1;
+}
+
+message ExposePortToContainerRequest {
+    uint32 Refid = 1;
+    string SrcContainerID = 2;
+    uint32 Port = 3;
+    string Protocol = 4;
+    string DstContainerID = 5;
+}
+
+message ExposePortToContainerResponse {
+    string error = 1;
+}
+
+message RemovePortFromContainerRequest {
+    uint32 Refid = 1;
+    string SrcContainerID = 2;
+    uint32 Port = 3;
+    string Protocol = 4;
+    string DstContainerID = 5;
+}
+
+message RemovePortFromContainerResponse {
+    string error = 1;
+}

--- a/pkg/abstraction/dcli.go
+++ b/pkg/abstraction/dcli.go
@@ -27,6 +27,7 @@ type DCli interface {
 	NetworkRemove(ctx context.Context, networkID string) error
 	NetworkConnect(ctx context.Context, networkID, containerID string, config *network.EndpointSettings) error
 	NetworkDisconnect(ctx context.Context, networkID, containerID string, force bool) error
+	NetworkInspect(ctx context.Context, networkID string) (types.NetworkResource, error)
 }
 
 type dcliAbstract struct {
@@ -88,6 +89,10 @@ func (d dcliAbstract) NetworkConnect(ctx context.Context, networkID, containerID
 
 func (d dcliAbstract) NetworkDisconnect(ctx context.Context, networkID, containerID string, force bool) error {
 	return d.cli.NetworkDisconnect(ctx, networkID, containerID, force)
+}
+
+func (d dcliAbstract) NetworkInspect(ctx context.Context, networkID string) (types.NetworkResource, error) {
+	return d.cli.NetworkInspect(ctx, networkID)
 }
 
 // NewDCLI returns an new Wrapper instance

--- a/pkg/abstraction/dcli.go
+++ b/pkg/abstraction/dcli.go
@@ -27,7 +27,7 @@ type DCli interface {
 	NetworkRemove(ctx context.Context, networkID string) error
 	NetworkConnect(ctx context.Context, networkID, containerID string, config *network.EndpointSettings) error
 	NetworkDisconnect(ctx context.Context, networkID, containerID string, force bool) error
-	NetworkInspect(ctx context.Context, networkID string) (types.NetworkResource, error)
+	NetworkInspect(ctx context.Context, networkID string, verbose bool) (types.NetworkResource, error)
 }
 
 type dcliAbstract struct {
@@ -91,8 +91,8 @@ func (d dcliAbstract) NetworkDisconnect(ctx context.Context, networkID, containe
 	return d.cli.NetworkDisconnect(ctx, networkID, containerID, force)
 }
 
-func (d dcliAbstract) NetworkInspect(ctx context.Context, networkID string) (types.NetworkResource, error) {
-	return d.cli.NetworkInspect(ctx, networkID)
+func (d dcliAbstract) NetworkInspect(ctx context.Context, networkID string, verbose bool) (types.NetworkResource, error) {
+	return d.cli.NetworkInspect(ctx, networkID, verbose)
 }
 
 // NewDCLI returns an new Wrapper instance

--- a/pkg/network/client/client.go
+++ b/pkg/network/client/client.go
@@ -1,0 +1,261 @@
+package client
+
+import (
+	"context"
+	"errors"
+
+	"github.com/go-kit/kit/endpoint"
+	"github.com/go-kit/kit/log"
+	grpctransport "github.com/go-kit/kit/transport/grpc"
+	"google.golang.org/grpc"
+
+	"github.com/kontainerooo/kontainer.ooo/pkg/network"
+	"github.com/kontainerooo/kontainer.ooo/pkg/pb"
+)
+
+// New creates a set of endpoints based on a gRPC connection
+func New(conn *grpc.ClientConn, logger log.Logger) *network.Endpoints {
+	var CreatePrimaryNetworkForContainerEndpoint endpoint.Endpoint
+	{
+		CreatePrimaryNetworkForContainerEndpoint = grpctransport.NewClient(
+			conn,
+			"networkService",
+			"CreatePrimaryNetworkForContainer",
+			EncodeGRPCCreatePrimaryNetworkForContainerRequest,
+			DecodeGRPCCreatePrimaryNetworkForContainerResponse,
+			pb.CreatePrimaryNetworkForContainerResponse{},
+		).Endpoint()
+	}
+	var CreateNetworkEndpoint endpoint.Endpoint
+	{
+		CreateNetworkEndpoint = grpctransport.NewClient(
+			conn,
+			"networkService",
+			"CreateNetwork",
+			EncodeGRPCCreateNetworkRequest,
+			DecodeGRPCCreateNetworkResponse,
+			pb.CreateNetworkResponse{},
+		).Endpoint()
+	}
+	var RemoveNetworkByNameEndpoint endpoint.Endpoint
+	{
+		RemoveNetworkByNameEndpoint = grpctransport.NewClient(
+			conn,
+			"networkService",
+			"RemoveNetworkByName",
+			EncodeGRPCRemoveNetworkByNameRequest,
+			DecodeGRPCRemoveNetworkByNameResponse,
+			pb.RemoveNetworkByNameResponse{},
+		).Endpoint()
+	}
+	var AddContainerToNetworkEndpoint endpoint.Endpoint
+	{
+		AddContainerToNetworkEndpoint = grpctransport.NewClient(
+			conn,
+			"networkService",
+			"AddContainerToNetwork",
+			EncodeGRPCAddContainerToNetworkRequest,
+			DecodeGRPCAddContainerToNetworkResponse,
+			pb.AddContainerToNetworkResponse{},
+		).Endpoint()
+	}
+	var RemoveContainerFromNetworkEndpoint endpoint.Endpoint
+	{
+		RemoveContainerFromNetworkEndpoint = grpctransport.NewClient(
+			conn,
+			"networkService",
+			"RemoveContainerFromNetwork",
+			EncodeGRPCRemoveContainerFromNetworkRequest,
+			DecodeGRPCRemoveContainerFromNetworkResponse,
+			pb.RemoveContainerFromNetworkResponse{},
+		).Endpoint()
+	}
+	var ExposePortToContainerEndpoint endpoint.Endpoint
+	{
+		ExposePortToContainerEndpoint = grpctransport.NewClient(
+			conn,
+			"networkService",
+			"ExposePortToContainer",
+			EncodeGRPCExposePortToContainerRequest,
+			DecodeGRPCExposePortToContainerResponse,
+			pb.ExposePortToContainerResponse{},
+		).Endpoint()
+	}
+	var RemovePortFromContainerEndpoint endpoint.Endpoint
+	{
+		RemovePortFromContainerEndpoint = grpctransport.NewClient(
+			conn,
+			"networkService",
+			"RemovePortFromContainer",
+			EncodeGRPCRemovePortFromContainerRequest,
+			DecodeGRPCRemovePortFromContainerResponse,
+			pb.RemovePortFromContainerResponse{},
+		).Endpoint()
+	}
+
+	return &network.Endpoints{
+		CreatePrimaryNetworkForContainerEndpoint: CreatePrimaryNetworkForContainerEndpoint,
+		CreateNetworkEndpoint:                    CreateNetworkEndpoint,
+		RemoveNetworkByNameEndpoint:              RemoveNetworkByNameEndpoint,
+		AddContainerToNetworkEndpoint:            AddContainerToNetworkEndpoint,
+		RemoveContainerFromNetworkEndpoint:       RemoveContainerFromNetworkEndpoint,
+		ExposePortToContainerEndpoint:            ExposePortToContainerEndpoint,
+		RemovePortFromContainerEndpoint:          RemovePortFromContainerEndpoint,
+	}
+}
+
+func getError(e string) error {
+	if e != "" {
+		return errors.New(e)
+	}
+	return nil
+}
+
+func nwConfigToPBConfig(c network.Config) *pb.NetworkConfig {
+	return &pb.NetworkConfig{
+		Driver: c.Driver,
+		Name:   c.Name,
+	}
+}
+
+// EncodeGRPCCreatePrimaryNetworkForContainerRequest is a transport/grpc.EncodeRequestFunc that converts a
+// messages/network.proto-domain createprimarynetworkforcontainer request to a gRPC CreatePrimaryNetworkForContainer request.
+func EncodeGRPCCreatePrimaryNetworkForContainerRequest(_ context.Context, request interface{}) (interface{}, error) {
+	req := request.(*network.CreatePrimaryNetworkForContainerRequest)
+	return &pb.CreatePrimaryNetworkForContainerRequest{
+		Refid:       uint32(req.Refid),
+		Config:      nwConfigToPBConfig(*req.Config),
+		ContainerID: req.ContainerID,
+	}, nil
+}
+
+// DecodeGRPCCreatePrimaryNetworkForContainerResponse is a transport/grpc.DecodeResponseFunc that converts a
+// gRPC CreatePrimaryNetworkForContainer response to a messages/network.proto-domain createprimarynetworkforcontainer response.
+func DecodeGRPCCreatePrimaryNetworkForContainerResponse(_ context.Context, grpcResponse interface{}) (interface{}, error) {
+	response := grpcResponse.(*pb.CreatePrimaryNetworkForContainerResponse)
+	return &network.CreatePrimaryNetworkForContainerResponse{
+		Error: getError(response.Error),
+	}, nil
+}
+
+// EncodeGRPCCreateNetworkRequest is a transport/grpc.EncodeRequestFunc that converts a
+// messages/network.proto-domain createnetwork request to a gRPC CreateNetwork request.
+func EncodeGRPCCreateNetworkRequest(_ context.Context, request interface{}) (interface{}, error) {
+	req := request.(*network.CreateNetworkRequest)
+	return &pb.CreateNetworkRequest{
+		Refid:  uint32(req.Refid),
+		Config: nwConfigToPBConfig(*req.Config),
+	}, nil
+}
+
+// DecodeGRPCCreateNetworkResponse is a transport/grpc.DecodeResponseFunc that converts a
+// gRPC CreateNetwork response to a messages/network.proto-domain createnetwork response.
+func DecodeGRPCCreateNetworkResponse(_ context.Context, grpcResponse interface{}) (interface{}, error) {
+	response := grpcResponse.(*pb.CreateNetworkResponse)
+	return &network.CreateNetworkResponse{
+		Error: getError(response.Error),
+	}, nil
+}
+
+// EncodeGRPCRemoveNetworkByNameRequest is a transport/grpc.EncodeRequestFunc that converts a
+// messages/network.proto-domain removenetworkbyname request to a gRPC RemoveNetworkByName request.
+func EncodeGRPCRemoveNetworkByNameRequest(_ context.Context, request interface{}) (interface{}, error) {
+	req := request.(*network.RemoveNetworkByNameRequest)
+	return &pb.RemoveNetworkByNameRequest{
+		Refid: uint32(req.Refid),
+		Name:  req.Name,
+	}, nil
+}
+
+// DecodeGRPCRemoveNetworkByNameResponse is a transport/grpc.DecodeResponseFunc that converts a
+// gRPC RemoveNetworkByName response to a messages/network.proto-domain removenetworkbyname response.
+func DecodeGRPCRemoveNetworkByNameResponse(_ context.Context, grpcResponse interface{}) (interface{}, error) {
+	response := grpcResponse.(*pb.RemoveNetworkByNameResponse)
+	return &network.RemoveNetworkByNameResponse{
+		Error: getError(response.Error),
+	}, nil
+}
+
+// EncodeGRPCAddContainerToNetworkRequest is a transport/grpc.EncodeRequestFunc that converts a
+// messages/network.proto-domain addcontainertonetwork request to a gRPC AddContainerToNetwork request.
+func EncodeGRPCAddContainerToNetworkRequest(_ context.Context, request interface{}) (interface{}, error) {
+	req := request.(*network.AddContainerToNetworkRequest)
+	return &pb.AddContainerToNetworkRequest{
+		Refid:       uint32(req.Refid),
+		Name:        req.Name,
+		ContainerID: req.ContainerID,
+	}, nil
+}
+
+// DecodeGRPCAddContainerToNetworkResponse is a transport/grpc.DecodeResponseFunc that converts a
+// gRPC AddContainerToNetwork response to a messages/network.proto-domain addcontainertonetwork response.
+func DecodeGRPCAddContainerToNetworkResponse(_ context.Context, grpcResponse interface{}) (interface{}, error) {
+	response := grpcResponse.(*pb.AddContainerToNetworkResponse)
+	return &network.AddContainerToNetworkResponse{
+		Error: getError(response.Error),
+	}, nil
+}
+
+// EncodeGRPCRemoveContainerFromNetworkRequest is a transport/grpc.EncodeRequestFunc that converts a
+// messages/network.proto-domain removecontainerfromnetwork request to a gRPC RemoveContainerFromNetwork request.
+func EncodeGRPCRemoveContainerFromNetworkRequest(_ context.Context, request interface{}) (interface{}, error) {
+	req := request.(*network.RemoveContainerFromNetworkRequest)
+	return &pb.RemoveContainerFromNetworkRequest{
+		Refid:       uint32(req.Refid),
+		Name:        req.Name,
+		ContainerID: req.ContainerID,
+	}, nil
+}
+
+// DecodeGRPCRemoveContainerFromNetworkResponse is a transport/grpc.DecodeResponseFunc that converts a
+// gRPC RemoveContainerFromNetwork response to a messages/network.proto-domain removecontainerfromnetwork response.
+func DecodeGRPCRemoveContainerFromNetworkResponse(_ context.Context, grpcResponse interface{}) (interface{}, error) {
+	response := grpcResponse.(*pb.RemoveContainerFromNetworkResponse)
+	return &network.RemoveContainerFromNetworkResponse{
+		Error: getError(response.Error),
+	}, nil
+}
+
+// EncodeGRPCExposePortToContainerRequest is a transport/grpc.EncodeRequestFunc that converts a
+// messages/network.proto-domain exposeporttocontainer request to a gRPC ExposePortToContainer request.
+func EncodeGRPCExposePortToContainerRequest(_ context.Context, request interface{}) (interface{}, error) {
+	req := request.(*network.ExposePortToContainerRequest)
+	return &pb.ExposePortToContainerRequest{
+		Refid:          uint32(req.Refid),
+		SrcContainerID: req.SrcContainerID,
+		DstContainerID: req.DstContainerID,
+		Port:           uint32(req.Port),
+		Protocol:       req.Protocol,
+	}, nil
+}
+
+// DecodeGRPCExposePortToContainerResponse is a transport/grpc.DecodeResponseFunc that converts a
+// gRPC ExposePortToContainer response to a messages/network.proto-domain exposeporttocontainer response.
+func DecodeGRPCExposePortToContainerResponse(_ context.Context, grpcResponse interface{}) (interface{}, error) {
+	response := grpcResponse.(*pb.ExposePortToContainerResponse)
+	return &network.ExposePortToContainerResponse{
+		Error: getError(response.Error),
+	}, nil
+}
+
+// EncodeGRPCRemovePortFromContainerRequest is a transport/grpc.EncodeRequestFunc that converts a
+// messages/network.proto-domain removeportfromcontainer request to a gRPC RemovePortFromContainer request.
+func EncodeGRPCRemovePortFromContainerRequest(_ context.Context, request interface{}) (interface{}, error) {
+	req := request.(*network.RemovePortFromContainerRequest)
+	return &pb.RemovePortFromContainerRequest{
+		Refid:          uint32(req.Refid),
+		SrcContainerID: req.SrcContainerID,
+		DstContainerID: req.DstContainerID,
+		Port:           uint32(req.Port),
+		Protocol:       req.Protocol,
+	}, nil
+}
+
+// DecodeGRPCRemovePortFromContainerResponse is a transport/grpc.DecodeResponseFunc that converts a
+// gRPC RemovePortFromContainer response to a messages/network.proto-domain removeportfromcontainer response.
+func DecodeGRPCRemovePortFromContainerResponse(_ context.Context, grpcResponse interface{}) (interface{}, error) {
+	response := grpcResponse.(*pb.RemovePortFromContainerResponse)
+	return &network.RemovePortFromContainerResponse{
+		Error: getError(response.Error),
+	}, nil
+}

--- a/pkg/network/datatypes.go
+++ b/pkg/network/datatypes.go
@@ -23,3 +23,13 @@ type Config struct {
 	Name   string
 	Driver string
 }
+
+// exposeData is the data needed for an expose rule
+type exposeData struct {
+	Port       uint16
+	SrcIP      abstraction.Inet
+	DstIP      abstraction.Inet
+	DstNetwork string
+	SrcNetwork string
+	Protocol   string
+}

--- a/pkg/network/datatypes.go
+++ b/pkg/network/datatypes.go
@@ -1,11 +1,21 @@
 // Package network handles container networks and interconnections
 package network
 
+import "github.com/kontainerooo/kontainer.ooo/pkg/abstraction"
+
 // Networks stores the networks belonging to a user
 type Networks struct {
 	UserID      uint
 	NetworkID   string `gorm:"primary_key"`
 	NetworkName string
+	IsPrimary   bool
+}
+
+// Containers map containers to their networks
+type Containers struct {
+	NetworkID   string
+	ContainerID string
+	ContainerIP abstraction.Inet `gorm:"primary_key"`
 }
 
 // Config describes configuration options for Networks

--- a/pkg/network/endpoint.go
+++ b/pkg/network/endpoint.go
@@ -1,0 +1,181 @@
+package network
+
+import (
+	"context"
+
+	"github.com/go-kit/kit/endpoint"
+)
+
+// Endpoints is a struct which collects all endpoints for the network service
+type Endpoints struct {
+	CreatePrimaryNetworkForContainerEndpoint endpoint.Endpoint
+	CreateNetworkEndpoint                    endpoint.Endpoint
+	RemoveNetworkByNameEndpoint              endpoint.Endpoint
+	AddContainerToNetworkEndpoint            endpoint.Endpoint
+	RemoveContainerFromNetworkEndpoint       endpoint.Endpoint
+	ExposePortToContainerEndpoint            endpoint.Endpoint
+	RemovePortFromContainerEndpoint          endpoint.Endpoint
+}
+
+// CreatePrimaryNetworkForContainerRequest is the request struct for the CreatePrimaryNetworkForContainerEndpoint
+type CreatePrimaryNetworkForContainerRequest struct {
+	Refid       uint
+	Config      *Config
+	ContainerID string
+}
+
+// CreatePrimaryNetworkForContainerResponse is the response struct for the CreatePrimaryNetworkForContainerEndpoint
+type CreatePrimaryNetworkForContainerResponse struct {
+	Error error
+}
+
+// MakeCreatePrimaryNetworkForContainerEndpoint creates a gokit endpoint which invokes CreatePrimaryNetworkForContainer
+func MakeCreatePrimaryNetworkForContainerEndpoint(s Service) endpoint.Endpoint {
+	return func(ctx context.Context, request interface{}) (interface{}, error) {
+		req := request.(CreatePrimaryNetworkForContainerRequest)
+		err := s.CreatePrimaryNetworkForContainer(req.Refid, req.Config, req.ContainerID)
+		return CreatePrimaryNetworkForContainerResponse{
+			Error: err,
+		}, nil
+	}
+}
+
+// CreateNetworkRequest is the request struct for the CreateNetworkEndpoint
+type CreateNetworkRequest struct {
+	Refid  uint
+	Config *Config
+}
+
+// CreateNetworkResponse is the response struct for the CreateNetworkEndpoint
+type CreateNetworkResponse struct {
+	Error error
+}
+
+// MakeCreateNetworkEndpoint creates a gokit endpoint which invokes CreateNetwork
+func MakeCreateNetworkEndpoint(s Service) endpoint.Endpoint {
+	return func(ctx context.Context, request interface{}) (interface{}, error) {
+		req := request.(CreateNetworkRequest)
+		err := s.CreateNetwork(req.Refid, req.Config)
+		return CreateNetworkResponse{
+			Error: err,
+		}, nil
+	}
+}
+
+// RemoveNetworkByNameRequest is the request struct for the RemoveNetworkByNameEndpoint
+type RemoveNetworkByNameRequest struct {
+	Refid uint
+	Name  string
+}
+
+// RemoveNetworkByNameResponse is the response struct for the RemoveNetworkByNameEndpoint
+type RemoveNetworkByNameResponse struct {
+	Error error
+}
+
+// MakeRemoveNetworkByNameEndpoint creates a gokit endpoint which invokes RemoveNetworkByName
+func MakeRemoveNetworkByNameEndpoint(s Service) endpoint.Endpoint {
+	return func(ctx context.Context, request interface{}) (interface{}, error) {
+		req := request.(RemoveNetworkByNameRequest)
+		err := s.RemoveNetworkByName(req.Refid, req.Name)
+		return RemoveNetworkByNameResponse{
+			Error: err,
+		}, nil
+	}
+}
+
+// AddContainerToNetworkRequest is the request struct for the AddContainerToNetworkEndpoint
+type AddContainerToNetworkRequest struct {
+	Refid       uint
+	Name        string
+	ContainerID string
+}
+
+// AddContainerToNetworkResponse is the response struct for the AddContainerToNetworkEndpoint
+type AddContainerToNetworkResponse struct {
+	Error error
+}
+
+// MakeAddContainerToNetworkEndpoint creates a gokit endpoint which invokes AddContainerToNetwork
+func MakeAddContainerToNetworkEndpoint(s Service) endpoint.Endpoint {
+	return func(ctx context.Context, request interface{}) (interface{}, error) {
+		req := request.(AddContainerToNetworkRequest)
+		err := s.AddContainerToNetwork(req.Refid, req.Name, req.ContainerID)
+		return AddContainerToNetworkResponse{
+			Error: err,
+		}, nil
+	}
+}
+
+// RemoveContainerFromNetworkRequest is the request struct for the RemoveContainerFromNetworkEndpoint
+type RemoveContainerFromNetworkRequest struct {
+	Refid       uint
+	Name        string
+	ContainerID string
+}
+
+// RemoveContainerFromNetworkResponse is the response struct for the RemoveContainerFromNetworkEndpoint
+type RemoveContainerFromNetworkResponse struct {
+	Error error
+}
+
+// MakeRemoveContainerFromNetworkEndpoint creates a gokit endpoint which invokes RemoveContainerFromNetwork
+func MakeRemoveContainerFromNetworkEndpoint(s Service) endpoint.Endpoint {
+	return func(ctx context.Context, request interface{}) (interface{}, error) {
+		req := request.(RemoveContainerFromNetworkRequest)
+		err := s.RemoveContainerFromNetwork(req.Refid, req.Name, req.ContainerID)
+		return RemoveContainerFromNetworkResponse{
+			Error: err,
+		}, nil
+	}
+}
+
+// ExposePortToContainerRequest is the request struct for the ExposePortToContainerEndpoint
+type ExposePortToContainerRequest struct {
+	Refid          uint
+	SrcContainerID string
+	Port           uint16
+	Protocol       string
+	DstContainerID string
+}
+
+// ExposePortToContainerResponse is the response struct for the ExposePortToContainerEndpoint
+type ExposePortToContainerResponse struct {
+	Error error
+}
+
+// MakeExposePortToContainerEndpoint creates a gokit endpoint which invokes ExposePortToContainer
+func MakeExposePortToContainerEndpoint(s Service) endpoint.Endpoint {
+	return func(ctx context.Context, request interface{}) (interface{}, error) {
+		req := request.(ExposePortToContainerRequest)
+		err := s.ExposePortToContainer(req.Refid, req.SrcContainerID, req.Port, req.Protocol, req.DstContainerID)
+		return ExposePortToContainerResponse{
+			Error: err,
+		}, nil
+	}
+}
+
+// RemovePortFromContainerRequest is the request struct for the RemovePortFromContainerEndpoint
+type RemovePortFromContainerRequest struct {
+	Refid          uint
+	SrcContainerID string
+	Port           uint16
+	Protocol       string
+	DstContainerID string
+}
+
+// RemovePortFromContainerResponse is the response struct for the RemovePortFromContainerEndpoint
+type RemovePortFromContainerResponse struct {
+	Error error
+}
+
+// MakeRemovePortFromContainerEndpoint creates a gokit endpoint which invokes RemovePortFromContainer
+func MakeRemovePortFromContainerEndpoint(s Service) endpoint.Endpoint {
+	return func(ctx context.Context, request interface{}) (interface{}, error) {
+		req := request.(RemovePortFromContainerRequest)
+		err := s.RemovePortFromContainer(req.Refid, req.SrcContainerID, req.Port, req.Protocol, req.DstContainerID)
+		return RemovePortFromContainerResponse{
+			Error: err,
+		}, nil
+	}
+}

--- a/pkg/network/network_test.go
+++ b/pkg/network/network_test.go
@@ -233,42 +233,4 @@ var _ = Describe("Network", func() {
 			Ω(err).Should(HaveOccurred())
 		})
 	})
-
-	Describe("Check if user has a network", func() {
-		dcli := testutils.NewMockDCli()
-		db := testutils.NewMockDB()
-		ccs := customercontainer.NewService(dcli)
-		networkService, _ := network.NewService(dcli, db)
-		dcli.CreateMockImage("testimage")
-		_, _, _ = ccs.CreateContainer(123, &customercontainer.ContainerConfig{
-			ImageName: "testimage",
-		})
-
-		It("Should return true when user has a network", func() {
-			_ = networkService.CreateNetwork(123, &network.Config{
-				Driver: "bridge",
-				Name:   "network1",
-			})
-
-			b := networkService.UserHasNetwork(123)
-
-			Ω(b).Should(BeTrue())
-		})
-
-		It("Should return false when user does not have a network", func() {
-			networkService.RemoveNetworkByName(123, "network1")
-
-			b := networkService.UserHasNetwork(123)
-
-			Ω(b).ShouldNot(BeTrue())
-		})
-
-		It("Should return false when DB errors", func() {
-			db.SetError(1)
-
-			b := networkService.UserHasNetwork(123)
-
-			Ω(b).ShouldNot(BeTrue())
-		})
-	})
 })

--- a/pkg/network/service.go
+++ b/pkg/network/service.go
@@ -188,7 +188,7 @@ func (s *service) AddContainerToNetwork(refid uint, name string, containerID str
 		}
 
 		// Check which IP address we got
-		information, err := s.dcli.NetworkInspect(context.Background(), nw.NetworkID)
+		information, err := s.dcli.NetworkInspect(context.Background(), nw.NetworkID, false)
 		if err != nil {
 			return err
 		}

--- a/pkg/network/service.go
+++ b/pkg/network/service.go
@@ -53,7 +53,6 @@ type dbAdapter interface {
 	Find(interface{}, ...interface{}) error
 	Create(interface{}) error
 	Delete(interface{}, ...interface{}) error
-	PrintTables()
 }
 
 type service struct {

--- a/pkg/network/service.go
+++ b/pkg/network/service.go
@@ -95,7 +95,6 @@ func (s *service) createNetwork(refid uint, cfg *Config, isPrimary bool) error {
 		return err
 	}
 
-	s.db.Begin()
 	nw = Networks{
 		UserID:      uint(refid),
 		NetworkName: name,
@@ -104,14 +103,12 @@ func (s *service) createNetwork(refid uint, cfg *Config, isPrimary bool) error {
 	}
 
 	err = s.db.Create(&nw)
-	fmt.Println(err)
 	if err != nil {
-		s.db.Rollback()
 		// Try to remove the actual network on db error
 		s.dcli.NetworkRemove(context.Background(), res.ID)
 		return err
 	}
-	s.db.Commit()
+
 	return nil
 }
 

--- a/pkg/network/service.go
+++ b/pkg/network/service.go
@@ -253,13 +253,6 @@ func (s *service) getContainerNetworks(containerID string) ([]Containers, error)
 		return []Containers{}, err
 	}
 
-	// TEMPORARY: until mockDB is fixed
-	for i, v := range cts {
-		if v.ContainerID != containerID {
-			cts = append(cts[:i], cts[i+1:]...)
-		}
-	}
-
 	return cts, nil
 }
 

--- a/pkg/network/transport_grpc.go
+++ b/pkg/network/transport_grpc.go
@@ -1,0 +1,297 @@
+package network
+
+import (
+	"context"
+
+	"github.com/go-kit/kit/log"
+	grpctransport "github.com/go-kit/kit/transport/grpc"
+	"github.com/kontainerooo/kontainer.ooo/pkg/pb"
+	oldcontext "golang.org/x/net/context"
+)
+
+// MakeGRPCServer makes a set of Endpoints available as a gRPC networkServer
+func MakeGRPCServer(ctx context.Context, endpoints Endpoints, logger log.Logger) pb.NetworkServiceServer {
+	options := []grpctransport.ServerOption{
+		grpctransport.ServerErrorLogger(logger),
+	}
+	return &grpcServer{
+		createprimarynetworkforcontainer: grpctransport.NewServer(
+			endpoints.CreatePrimaryNetworkForContainerEndpoint,
+			DecodeGRPCCreatePrimaryNetworkForContainerRequest,
+			EncodeGRPCCreatePrimaryNetworkForContainerResponse,
+			options...,
+		),
+		createnetwork: grpctransport.NewServer(
+			endpoints.CreateNetworkEndpoint,
+			DecodeGRPCCreateNetworkRequest,
+			EncodeGRPCCreateNetworkResponse,
+			options...,
+		),
+		removenetworkbyname: grpctransport.NewServer(
+			endpoints.RemoveNetworkByNameEndpoint,
+			DecodeGRPCRemoveNetworkByNameRequest,
+			EncodeGRPCRemoveNetworkByNameResponse,
+			options...,
+		),
+		addcontainertonetwork: grpctransport.NewServer(
+			endpoints.AddContainerToNetworkEndpoint,
+			DecodeGRPCAddContainerToNetworkRequest,
+			EncodeGRPCAddContainerToNetworkResponse,
+			options...,
+		),
+		removecontainerfromnetwork: grpctransport.NewServer(
+			endpoints.RemoveContainerFromNetworkEndpoint,
+			DecodeGRPCRemoveContainerFromNetworkRequest,
+			EncodeGRPCRemoveContainerFromNetworkResponse,
+			options...,
+		),
+		exposeporttocontainer: grpctransport.NewServer(
+			endpoints.ExposePortToContainerEndpoint,
+			DecodeGRPCExposePortToContainerRequest,
+			EncodeGRPCExposePortToContainerResponse,
+			options...,
+		),
+		removeportfromcontainer: grpctransport.NewServer(
+			endpoints.RemovePortFromContainerEndpoint,
+			DecodeGRPCRemovePortFromContainerRequest,
+			EncodeGRPCRemovePortFromContainerResponse,
+			options...,
+		),
+	}
+}
+
+type grpcServer struct {
+	createprimarynetworkforcontainer grpctransport.Handler
+	createnetwork                    grpctransport.Handler
+	removenetworkbyname              grpctransport.Handler
+	addcontainertonetwork            grpctransport.Handler
+	removecontainerfromnetwork       grpctransport.Handler
+	exposeporttocontainer            grpctransport.Handler
+	removeportfromcontainer          grpctransport.Handler
+}
+
+func (s *grpcServer) CreatePrimaryNetworkForContainer(ctx oldcontext.Context, req *pb.CreatePrimaryNetworkForContainerRequest) (*pb.CreatePrimaryNetworkForContainerResponse, error) {
+	_, res, err := s.createprimarynetworkforcontainer.ServeGRPC(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	return res.(*pb.CreatePrimaryNetworkForContainerResponse), nil
+}
+
+func (s *grpcServer) CreateNetwork(ctx oldcontext.Context, req *pb.CreateNetworkRequest) (*pb.CreateNetworkResponse, error) {
+	_, res, err := s.createnetwork.ServeGRPC(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	return res.(*pb.CreateNetworkResponse), nil
+}
+
+func (s *grpcServer) RemoveNetworkByName(ctx oldcontext.Context, req *pb.RemoveNetworkByNameRequest) (*pb.RemoveNetworkByNameResponse, error) {
+	_, res, err := s.removenetworkbyname.ServeGRPC(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	return res.(*pb.RemoveNetworkByNameResponse), nil
+}
+
+func (s *grpcServer) AddContainerToNetwork(ctx oldcontext.Context, req *pb.AddContainerToNetworkRequest) (*pb.AddContainerToNetworkResponse, error) {
+	_, res, err := s.addcontainertonetwork.ServeGRPC(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	return res.(*pb.AddContainerToNetworkResponse), nil
+}
+
+func (s *grpcServer) RemoveContainerFromNetwork(ctx oldcontext.Context, req *pb.RemoveContainerFromNetworkRequest) (*pb.RemoveContainerFromNetworkResponse, error) {
+	_, res, err := s.removecontainerfromnetwork.ServeGRPC(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	return res.(*pb.RemoveContainerFromNetworkResponse), nil
+}
+
+func (s *grpcServer) ExposePortToContainer(ctx oldcontext.Context, req *pb.ExposePortToContainerRequest) (*pb.ExposePortToContainerResponse, error) {
+	_, res, err := s.exposeporttocontainer.ServeGRPC(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	return res.(*pb.ExposePortToContainerResponse), nil
+}
+
+func (s *grpcServer) RemovePortFromContainer(ctx oldcontext.Context, req *pb.RemovePortFromContainerRequest) (*pb.RemovePortFromContainerResponse, error) {
+	_, res, err := s.removeportfromcontainer.ServeGRPC(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	return res.(*pb.RemovePortFromContainerResponse), nil
+}
+
+func nwConfigToPBConfig(c Config) *pb.NetworkConfig {
+	return &pb.NetworkConfig{
+		Driver: c.Driver,
+		Name:   c.Name,
+	}
+}
+
+func pbConfigToNWConfig(c pb.NetworkConfig) *Config {
+	return &Config{
+		Driver: c.Driver,
+		Name:   c.Name,
+	}
+}
+
+// DecodeGRPCCreatePrimaryNetworkForContainerRequest is a transport/grpc.DecodeRequestFunc that converts a
+// gRPC CreatePrimaryNetworkForContainer request to a messages/network.proto-domain createprimarynetworkforcontainer request.
+func DecodeGRPCCreatePrimaryNetworkForContainerRequest(_ context.Context, grpcReq interface{}) (interface{}, error) {
+	req := grpcReq.(*pb.CreatePrimaryNetworkForContainerRequest)
+	return CreatePrimaryNetworkForContainerRequest{
+		Refid:       uint(req.Refid),
+		Config:      pbConfigToNWConfig(*req.Config),
+		ContainerID: req.ContainerID,
+	}, nil
+}
+
+// DecodeGRPCCreateNetworkRequest is a transport/grpc.DecodeRequestFunc that converts a
+// gRPC CreateNetwork request to a messages/network.proto-domain createnetwork request.
+func DecodeGRPCCreateNetworkRequest(_ context.Context, grpcReq interface{}) (interface{}, error) {
+	req := grpcReq.(*pb.CreateNetworkRequest)
+	return CreateNetworkRequest{
+		Refid:  uint(req.Refid),
+		Config: pbConfigToNWConfig(*req.Config),
+	}, nil
+}
+
+// DecodeGRPCRemoveNetworkByNameRequest is a transport/grpc.DecodeRequestFunc that converts a
+// gRPC RemoveNetworkByName request to a messages/network.proto-domain removenetworkbyname request.
+func DecodeGRPCRemoveNetworkByNameRequest(_ context.Context, grpcReq interface{}) (interface{}, error) {
+	req := grpcReq.(*pb.RemoveNetworkByNameRequest)
+	return RemoveNetworkByNameRequest{
+		Refid: uint(req.Refid),
+		Name:  req.Name,
+	}, nil
+}
+
+// DecodeGRPCAddContainerToNetworkRequest is a transport/grpc.DecodeRequestFunc that converts a
+// gRPC AddContainerToNetwork request to a messages/network.proto-domain addcontainertonetwork request.
+func DecodeGRPCAddContainerToNetworkRequest(_ context.Context, grpcReq interface{}) (interface{}, error) {
+	req := grpcReq.(*pb.AddContainerToNetworkRequest)
+	return AddContainerToNetworkRequest{
+		Refid:       uint(req.Refid),
+		Name:        req.Name,
+		ContainerID: req.ContainerID,
+	}, nil
+}
+
+// DecodeGRPCRemoveContainerFromNetworkRequest is a transport/grpc.DecodeRequestFunc that converts a
+// gRPC RemoveContainerFromNetwork request to a messages/network.proto-domain removecontainerfromnetwork request.
+func DecodeGRPCRemoveContainerFromNetworkRequest(_ context.Context, grpcReq interface{}) (interface{}, error) {
+	req := grpcReq.(*pb.RemoveContainerFromNetworkRequest)
+	return RemoveContainerFromNetworkRequest{
+		Refid:       uint(req.Refid),
+		Name:        req.Name,
+		ContainerID: req.ContainerID,
+	}, nil
+}
+
+// DecodeGRPCExposePortToContainerRequest is a transport/grpc.DecodeRequestFunc that converts a
+// gRPC ExposePortToContainer request to a messages/network.proto-domain exposeporttocontainer request.
+func DecodeGRPCExposePortToContainerRequest(_ context.Context, grpcReq interface{}) (interface{}, error) {
+	req := grpcReq.(*pb.ExposePortToContainerRequest)
+	return ExposePortToContainerRequest{
+		Refid:          uint(req.Refid),
+		SrcContainerID: req.SrcContainerID,
+		Port:           uint16(req.Port),
+		Protocol:       req.Protocol,
+		DstContainerID: req.DstContainerID,
+	}, nil
+}
+
+// DecodeGRPCRemovePortFromContainerRequest is a transport/grpc.DecodeRequestFunc that converts a
+// gRPC RemovePortFromContainer request to a messages/network.proto-domain removeportfromcontainer request.
+func DecodeGRPCRemovePortFromContainerRequest(_ context.Context, grpcReq interface{}) (interface{}, error) {
+	req := grpcReq.(*pb.RemovePortFromContainerRequest)
+	return RemovePortFromContainerRequest{
+		Refid:          uint(req.Refid),
+		SrcContainerID: req.SrcContainerID,
+		Port:           uint16(req.Port),
+		Protocol:       req.Protocol,
+		DstContainerID: req.DstContainerID,
+	}, nil
+}
+
+// EncodeGRPCCreatePrimaryNetworkForContainerResponse is a transport/grpc.EncodeRequestFunc that converts a
+// messages/network.proto-domain createprimarynetworkforcontainer response to a gRPC CreatePrimaryNetworkForContainer response.
+func EncodeGRPCCreatePrimaryNetworkForContainerResponse(_ context.Context, response interface{}) (interface{}, error) {
+	res := response.(CreatePrimaryNetworkForContainerResponse)
+	gRPCRes := &pb.CreatePrimaryNetworkForContainerResponse{}
+	if res.Error != nil {
+		gRPCRes.Error = res.Error.Error()
+	}
+	return gRPCRes, nil
+}
+
+// EncodeGRPCCreateNetworkResponse is a transport/grpc.EncodeRequestFunc that converts a
+// messages/network.proto-domain createnetwork response to a gRPC CreateNetwork response.
+func EncodeGRPCCreateNetworkResponse(_ context.Context, response interface{}) (interface{}, error) {
+	res := response.(CreateNetworkResponse)
+	gRPCRes := &pb.CreateNetworkResponse{}
+	if res.Error != nil {
+		gRPCRes.Error = res.Error.Error()
+	}
+	return gRPCRes, nil
+}
+
+// EncodeGRPCRemoveNetworkByNameResponse is a transport/grpc.EncodeRequestFunc that converts a
+// messages/network.proto-domain removenetworkbyname response to a gRPC RemoveNetworkByName response.
+func EncodeGRPCRemoveNetworkByNameResponse(_ context.Context, response interface{}) (interface{}, error) {
+	res := response.(RemoveNetworkByNameResponse)
+	gRPCRes := &pb.RemoveNetworkByNameResponse{}
+	if res.Error != nil {
+		gRPCRes.Error = res.Error.Error()
+	}
+	return gRPCRes, nil
+}
+
+// EncodeGRPCAddContainerToNetworkResponse is a transport/grpc.EncodeRequestFunc that converts a
+// messages/network.proto-domain addcontainertonetwork response to a gRPC AddContainerToNetwork response.
+func EncodeGRPCAddContainerToNetworkResponse(_ context.Context, response interface{}) (interface{}, error) {
+	res := response.(AddContainerToNetworkResponse)
+	gRPCRes := &pb.AddContainerToNetworkResponse{}
+	if res.Error != nil {
+		gRPCRes.Error = res.Error.Error()
+	}
+	return gRPCRes, nil
+}
+
+// EncodeGRPCRemoveContainerFromNetworkResponse is a transport/grpc.EncodeRequestFunc that converts a
+// messages/network.proto-domain removecontainerfromnetwork response to a gRPC RemoveContainerFromNetwork response.
+func EncodeGRPCRemoveContainerFromNetworkResponse(_ context.Context, response interface{}) (interface{}, error) {
+	res := response.(RemoveContainerFromNetworkResponse)
+	gRPCRes := &pb.RemoveContainerFromNetworkResponse{}
+	if res.Error != nil {
+		gRPCRes.Error = res.Error.Error()
+	}
+	return gRPCRes, nil
+}
+
+// EncodeGRPCExposePortToContainerResponse is a transport/grpc.EncodeRequestFunc that converts a
+// messages/network.proto-domain exposeporttocontainer response to a gRPC ExposePortToContainer response.
+func EncodeGRPCExposePortToContainerResponse(_ context.Context, response interface{}) (interface{}, error) {
+	res := response.(ExposePortToContainerResponse)
+	gRPCRes := &pb.ExposePortToContainerResponse{}
+	if res.Error != nil {
+		gRPCRes.Error = res.Error.Error()
+	}
+	return gRPCRes, nil
+}
+
+// EncodeGRPCRemovePortFromContainerResponse is a transport/grpc.EncodeRequestFunc that converts a
+// messages/network.proto-domain removeportfromcontainer response to a gRPC RemovePortFromContainer response.
+func EncodeGRPCRemovePortFromContainerResponse(_ context.Context, response interface{}) (interface{}, error) {
+	res := response.(RemovePortFromContainerResponse)
+	gRPCRes := &pb.RemovePortFromContainerResponse{}
+	if res.Error != nil {
+		gRPCRes.Error = res.Error.Error()
+	}
+	return gRPCRes, nil
+}

--- a/pkg/network/transport_ws.go
+++ b/pkg/network/transport_ws.go
@@ -1,0 +1,156 @@
+package network
+
+import (
+	"context"
+
+	"github.com/golang/protobuf/proto"
+	"github.com/kontainerooo/kontainer.ooo/pkg/pb"
+	ws "github.com/kontainerooo/kontainer.ooo/pkg/websocket"
+)
+
+// MakeWebsocketService makes a set of network Endpoints available as a websocket Service
+func MakeWebsocketService(endpoints Endpoints) *ws.ServiceDescription {
+	service := ws.NewServiceDescription("networkService", ws.ProtoIDFromString("network"))
+
+	service.AddEndpoint(ws.NewServiceEndpoint(
+		"CreatePrimaryNetworkForContainer",
+		ws.ProtoIDFromString(""),
+		endpoints.CreatePrimaryNetworkForContainerEndpoint,
+		DecodeWSCreatePrimaryNetworkForContainerRequest,
+		EncodeGRPCCreatePrimaryNetworkForContainerResponse,
+	))
+
+	service.AddEndpoint(ws.NewServiceEndpoint(
+		"CreateNetwork",
+		ws.ProtoIDFromString(""),
+		endpoints.CreateNetworkEndpoint,
+		DecodeWSCreateNetworkRequest,
+		EncodeGRPCCreateNetworkResponse,
+	))
+
+	service.AddEndpoint(ws.NewServiceEndpoint(
+		"RemoveNetworkByName",
+		ws.ProtoIDFromString(""),
+		endpoints.RemoveNetworkByNameEndpoint,
+		DecodeWSRemoveNetworkByNameRequest,
+		EncodeGRPCRemoveNetworkByNameResponse,
+	))
+
+	service.AddEndpoint(ws.NewServiceEndpoint(
+		"AddContainerToNetwork",
+		ws.ProtoIDFromString(""),
+		endpoints.AddContainerToNetworkEndpoint,
+		DecodeWSAddContainerToNetworkRequest,
+		EncodeGRPCAddContainerToNetworkResponse,
+	))
+
+	service.AddEndpoint(ws.NewServiceEndpoint(
+		"RemoveContainerFromNetwork",
+		ws.ProtoIDFromString(""),
+		endpoints.RemoveContainerFromNetworkEndpoint,
+		DecodeWSRemoveContainerFromNetworkRequest,
+		EncodeGRPCRemoveContainerFromNetworkResponse,
+	))
+
+	service.AddEndpoint(ws.NewServiceEndpoint(
+		"ExposePortToContainer",
+		ws.ProtoIDFromString(""),
+		endpoints.ExposePortToContainerEndpoint,
+		DecodeWSExposePortToContainerRequest,
+		EncodeGRPCExposePortToContainerResponse,
+	))
+
+	service.AddEndpoint(ws.NewServiceEndpoint(
+		"RemovePortFromContainer",
+		ws.ProtoIDFromString(""),
+		endpoints.RemovePortFromContainerEndpoint,
+		DecodeWSRemovePortFromContainerRequest,
+		EncodeGRPCRemovePortFromContainerResponse,
+	))
+
+	return service
+}
+
+// DecodeWSCreatePrimaryNetworkForContainerRequest is a websocket.DecodeRequestFunc that converts a
+// WS CreatePrimaryNetworkForContainer request to a messages/network.proto-domain createprimarynetworkforcontainer request.
+func DecodeWSCreatePrimaryNetworkForContainerRequest(ctx context.Context, data interface{}) (interface{}, error) {
+	req := &pb.CreatePrimaryNetworkForContainerRequest{}
+	err := proto.Unmarshal(data.([]byte), req)
+	if err != nil {
+		return nil, err
+	}
+
+	return DecodeGRPCCreatePrimaryNetworkForContainerRequest(ctx, req)
+}
+
+// DecodeWSCreateNetworkRequest is a websocket.DecodeRequestFunc that converts a
+// WS CreateNetwork request to a messages/network.proto-domain createnetwork request.
+func DecodeWSCreateNetworkRequest(ctx context.Context, data interface{}) (interface{}, error) {
+	req := &pb.CreateNetworkRequest{}
+	err := proto.Unmarshal(data.([]byte), req)
+	if err != nil {
+		return nil, err
+	}
+
+	return DecodeGRPCCreateNetworkRequest(ctx, req)
+}
+
+// DecodeWSRemoveNetworkByNameRequest is a websocket.DecodeRequestFunc that converts a
+// WS RemoveNetworkByName request to a messages/network.proto-domain removenetworkbyname request.
+func DecodeWSRemoveNetworkByNameRequest(ctx context.Context, data interface{}) (interface{}, error) {
+	req := &pb.RemoveNetworkByNameRequest{}
+	err := proto.Unmarshal(data.([]byte), req)
+	if err != nil {
+		return nil, err
+	}
+
+	return DecodeGRPCRemoveNetworkByNameRequest(ctx, req)
+}
+
+// DecodeWSAddContainerToNetworkRequest is a websocket.DecodeRequestFunc that converts a
+// WS AddContainerToNetwork request to a messages/network.proto-domain addcontainertonetwork request.
+func DecodeWSAddContainerToNetworkRequest(ctx context.Context, data interface{}) (interface{}, error) {
+	req := &pb.AddContainerToNetworkRequest{}
+	err := proto.Unmarshal(data.([]byte), req)
+	if err != nil {
+		return nil, err
+	}
+
+	return DecodeGRPCAddContainerToNetworkRequest(ctx, req)
+}
+
+// DecodeWSRemoveContainerFromNetworkRequest is a websocket.DecodeRequestFunc that converts a
+// WS RemoveContainerFromNetwork request to a messages/network.proto-domain removecontainerfromnetwork request.
+func DecodeWSRemoveContainerFromNetworkRequest(ctx context.Context, data interface{}) (interface{}, error) {
+	req := &pb.RemoveContainerFromNetworkRequest{}
+	err := proto.Unmarshal(data.([]byte), req)
+	if err != nil {
+		return nil, err
+	}
+
+	return DecodeGRPCRemoveContainerFromNetworkRequest(ctx, req)
+}
+
+// DecodeWSExposePortToContainerRequest is a websocket.DecodeRequestFunc that converts a
+// WS ExposePortToContainer request to a messages/network.proto-domain exposeporttocontainer request.
+func DecodeWSExposePortToContainerRequest(ctx context.Context, data interface{}) (interface{}, error) {
+	req := &pb.ExposePortToContainerRequest{}
+	err := proto.Unmarshal(data.([]byte), req)
+	if err != nil {
+		return nil, err
+	}
+
+	return DecodeGRPCExposePortToContainerRequest(ctx, req)
+}
+
+// DecodeWSRemovePortFromContainerRequest is a websocket.DecodeRequestFunc that converts a
+// WS RemovePortFromContainer request to a messages/network.proto-domain removeportfromcontainer request.
+func DecodeWSRemovePortFromContainerRequest(ctx context.Context, data interface{}) (interface{}, error) {
+	req := &pb.RemovePortFromContainerRequest{}
+	err := proto.Unmarshal(data.([]byte), req)
+	if err != nil {
+		return nil, err
+	}
+
+	return DecodeGRPCRemovePortFromContainerRequest(ctx, req)
+}

--- a/pkg/testutils/mockFirewallClient.go
+++ b/pkg/testutils/mockFirewallClient.go
@@ -15,6 +15,7 @@ type MockFirewallClient struct {
 func NewMockFirewallEndpoints(logger log.Logger, m MockFirewallClient) *firewall.Endpoints {
 	return &firewall.Endpoints{
 		AllowPortEndpoint: m.AllowPortEndpoint,
+		BlockPortEndpoint: m.BlockPortEndpoint,
 	}
 }
 
@@ -23,6 +24,15 @@ func (m *MockFirewallClient) AllowPortEndpoint(ctx context.Context, req interfac
 	_ = req.(*firewall.AllowPortRequest)
 
 	return &firewall.AllowPortResponse{
+		Error: nil,
+	}, nil
+}
+
+// BlockPortEndpoint is a mock endpoint
+func (m *MockFirewallClient) BlockPortEndpoint(ctx context.Context, req interface{}) (interface{}, error) {
+	_ = req.(*firewall.BlockPortRequest)
+
+	return &firewall.BlockPortResponse{
 		Error: nil,
 	}, nil
 }

--- a/pkg/testutils/mockFirewallClient.go
+++ b/pkg/testutils/mockFirewallClient.go
@@ -1,0 +1,33 @@
+package testutils
+
+import (
+	"context"
+
+	"github.com/go-kit/kit/log"
+	"github.com/kontainerooo/kontainer.ooo/pkg/firewall"
+)
+
+// MockFirewallClient simulates a firewall client for testing purposes
+type MockFirewallClient struct {
+}
+
+// NewMockFirewallEndpoints creates a new MockFirewallClientEndpoints
+func NewMockFirewallEndpoints(logger log.Logger, m MockFirewallClient) *firewall.Endpoints {
+	return &firewall.Endpoints{
+		AllowPortEndpoint: m.AllowPortEndpoint,
+	}
+}
+
+// AllowPortEndpoint is a mock endpoint
+func (m *MockFirewallClient) AllowPortEndpoint(ctx context.Context, req interface{}) (interface{}, error) {
+	_ = req.(*firewall.AllowPortRequest)
+
+	return &firewall.AllowPortResponse{
+		Error: nil,
+	}, nil
+}
+
+// NewMockFirewallClient creates a new MockFirewallClient
+func NewMockFirewallClient() *MockFirewallClient {
+	return &MockFirewallClient{}
+}

--- a/pkg/testutils/mockIPT.go
+++ b/pkg/testutils/mockIPT.go
@@ -2,7 +2,6 @@ package testutils
 
 import (
 	"errors"
-	"fmt"
 	"os"
 	"os/exec"
 
@@ -29,8 +28,6 @@ func (m *MockIPTService) CreateRule(ruleType int, ruleData interface{}) error {
 	if err != nil {
 		return err
 	}
-
-	fmt.Println(m.rules)
 
 	_, ok := m.rules[re.ID]
 	if ok {

--- a/pkg/testutils/mockdb.go
+++ b/pkg/testutils/mockdb.go
@@ -322,9 +322,9 @@ func (m *MockDB) Delete(value interface{}, where ...interface{}) error {
 
 	v := reflect.ValueOf(value).Elem()
 
-	for i := 0; i < ref.NumField(); i++ {
-		f := ref.Field(i).Name
-		fv := v.Field(i)
+	for _, f := range m.tables[name].columns {
+		fv := v.FieldByName(f)
+
 		if !isZero(fv) {
 			ids[f] = fv
 		}

--- a/pkg/testutils/mockdb.go
+++ b/pkg/testutils/mockdb.go
@@ -274,9 +274,11 @@ func (m *MockDB) Find(out interface{}, where ...interface{}) error {
 	ref := reflect.TypeOf(out).Elem()
 	for _, t := range m.tables {
 		if ref == reflect.SliceOf(t.getRef()) {
-			err := t.all(out)
-			if err != nil {
-				return err
+			if reflect.TypeOf(out).Elem().Kind() == reflect.Slice {
+				for k, v := range m.multiValue {
+					val := v.values.Slice(0, 1).Index(k).Elem()
+					reflect.ValueOf(out).Elem().Set(reflect.Append(reflect.ValueOf(out).Elem(), val))
+				}
 			}
 			break
 		}

--- a/pkg/testutils/mockdb.go
+++ b/pkg/testutils/mockdb.go
@@ -218,13 +218,12 @@ func (m *MockDB) Where(query interface{}, args ...interface{}) error {
 				}
 				if !intersect {
 					// remove table from the multiValue property if it is not part of the new result array
-					m.multiValue = append(m.multiValue[:i], m.multiValue[i+1:]...)
-
-					// if nothing is left reset everything and return
-					if len(m.multiValue) == 0 {
+					if len(m.multiValue) == 1 {
 						m.multiValue = nil
 						return nil
 					}
+
+					m.multiValue = append(m.multiValue[:i], m.multiValue[i+1:]...)
 				}
 			}
 		}

--- a/pkg/testutils/mockdb.go
+++ b/pkg/testutils/mockdb.go
@@ -171,7 +171,7 @@ func (m *MockDB) Where(query interface{}, args ...interface{}) error {
 	for i, part := range and {
 		// get field name out of query
 		s := strings.Split(part, " ")
-		field := strings.Title(s[0])
+		field := s[0] //strings.Title(s[0])
 
 		// init result array
 		mValue := []*result{}
@@ -186,7 +186,7 @@ func (m *MockDB) Where(query interface{}, args ...interface{}) error {
 					return err
 				}
 				// update result array if the result isn't empty
-				if res != reflect.ValueOf(nil) {
+				if res != RNil {
 					mValue = append(mValue, &result{
 						table:  table.Name,
 						values: res,
@@ -197,7 +197,7 @@ func (m *MockDB) Where(query interface{}, args ...interface{}) error {
 
 		if i == 0 {
 			// if nothing is found stop and return
-			if mValue == nil {
+			if mValue == nil || len(mValue) == 0 {
 				return nil
 			}
 
@@ -304,9 +304,15 @@ func (m *MockDB) Delete(value interface{}, where ...interface{}) error {
 
 	ref := reflect.TypeOf(value).Elem()
 	name := ref.String()
-	table := m.tables[name]
-	for _, k := range table.PrimaryKey {
-		ids[k] = reflect.ValueOf(value).Elem().FieldByName(k)
+
+	v := reflect.ValueOf(value).Elem()
+
+	for i := 0; i < ref.NumField(); i++ {
+		f := ref.Field(i).Name
+		fv := v.Field(i)
+		if !isZero(fv) {
+			ids[f] = fv
+		}
 	}
 
 	if len(ids) != 0 {

--- a/pkg/testutils/mockdcli.go
+++ b/pkg/testutils/mockdcli.go
@@ -284,6 +284,21 @@ func (d *MockDCli) NetworkDisconnect(ctx context.Context, networkID, containerID
 	return ErrNetNotFound
 }
 
+// NetworkInspect returns network information
+func (d *MockDCli) NetworkInspect(ctx context.Context, networkID string) (types.NetworkResource, error) {
+	cts := make(map[string]types.EndpointResource)
+
+	for k := range d.containers {
+		cts[k] = types.EndpointResource{
+			IPv4Address: "127.0.0.2",
+		}
+	}
+
+	return types.NetworkResource{
+		Containers: cts,
+	}, nil
+}
+
 // NewMockDCli returns a new instance of MockDCli
 func NewMockDCli() *MockDCli {
 	return &MockDCli{

--- a/pkg/testutils/mockdcli.go
+++ b/pkg/testutils/mockdcli.go
@@ -285,7 +285,7 @@ func (d *MockDCli) NetworkDisconnect(ctx context.Context, networkID, containerID
 }
 
 // NetworkInspect returns network information
-func (d *MockDCli) NetworkInspect(ctx context.Context, networkID string) (types.NetworkResource, error) {
+func (d *MockDCli) NetworkInspect(ctx context.Context, networkID string, verbose bool) (types.NetworkResource, error) {
 	cts := make(map[string]types.EndpointResource)
 
 	for k := range d.containers {

--- a/pkg/testutils/table.go
+++ b/pkg/testutils/table.go
@@ -107,6 +107,11 @@ func (t *table) find(field string, value interface{}) (reflect.Value, error) {
 			if uint(v) == value {
 				result = reflect.Append(result, reflect.ValueOf(row))
 			}
+		} else if reflect.TypeOf(value).Kind() == reflect.Bool {
+			v := reflect.ValueOf(row).Elem().FieldByName(field).Bool()
+			if bool(v) == value {
+				result = reflect.Append(result, reflect.ValueOf(row))
+			}
 		} else {
 			v := reflect.ValueOf(row).Elem().FieldByName(field).String()
 			if v == value {

--- a/pkg/testutils/table.go
+++ b/pkg/testutils/table.go
@@ -57,6 +57,9 @@ func (t *table) all(out interface{}) error {
 }
 
 func (t *table) checkForField(f string) bool {
+	if f == gorm.ToDBName(f) {
+		f = t.columns[f]
+	}
 	_, found := t.ref.FieldByName(f)
 	return found
 }
@@ -91,10 +94,12 @@ func (t *table) find(field string, value interface{}) (reflect.Value, error) {
 	if field == gorm.ToDBName(field) {
 		field = t.columns[field]
 	}
+
 	_, found := t.ref.FieldByName(field)
 	if !found {
-		return reflect.ValueOf(nil), errors.New("field name not in struct")
+		return RNil, errors.New("field name not in struct")
 	}
+
 	result := reflect.MakeSlice(reflect.SliceOf(reflect.PtrTo(t.ref)), 0, 0)
 	for _, row := range t.rows {
 		if reflect.TypeOf(value).Kind() == reflect.Uint {

--- a/pkg/testutils/testutils.go
+++ b/pkg/testutils/testutils.go
@@ -38,6 +38,9 @@ func merge(dst, src reflect.Value, overwriteID bool, depth int) error {
 }
 
 func isZero(v reflect.Value) bool {
+	if v == RNil {
+		return true
+	}
 	switch v.Kind() {
 	case reflect.Array, reflect.String:
 		return v.Len() == 0


### PR DESCRIPTION
This PR updates the network service by implementing the remaining expose functions and creating the endpoints and transports.

**TODO:**
- [x] Update mock DB to return only matched data on `.Find()` 
- [x] Fix test errors in KMI service

Changes in `messages`: Create network service messages (resolve #108)

Changes in `pkg/abstraction`:
- Create `NetworkInspect` abstraction

Changes in `pkg/network/`:
- Create client
- Create endpoints (resolve #107)
- Create grpc transport (resolves #109)
- Create ws transport (resolves #159)
- Update datatypes (flag networks as primary and add new table for container-network-IPAddress mapping)
- Changes in `service.go`:
  - Add ability to create a primary network for container
  - Create Port expose and remove port exposure (resolve #104, resolve #105)

Changes in `pkg/testutils/`:
- Create simple mock firewall client for testing
- Remove unnecessary logging in mock ipt service
- Update mockdb to operate on bool values
- @tobuto -> other stuff in mock db
- Create `NetworkInspect` mock function

![](http://www.sepeb.com/cute-baby-animal-pictures/image_20170304_212729.jpg)